### PR TITLE
 #144 add dropdown directive to be used in Team filter dropdowns

### DIFF
--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -174,6 +174,7 @@
 <script src="js/directives/modelChangeBlur.js?t=${buildTime}"></script>
 <script src="js/directives/select2.js?t=${buildTime}"></script>
 <script src="js/directives/clickOutside.js?t=${buildTime}"></script>
+<script src="js/directives/dropdown.js?t=${buildTime}"></script>
 <script src="js/services/MainAlertService.js?t=${buildTime}"></script>
 <script src="js/services/CommunicationService.js?t=${buildTime}"></script>
 <script src="js/services/FeedbackMessageService.js?t=${buildTime}"></script>

--- a/zmon-controller-ui/js/directives/dropdown.js
+++ b/zmon-controller-ui/js/directives/dropdown.js
@@ -1,0 +1,34 @@
+angular.module('zmon2App').directive('dropdown', [ '$timeout', function($timeout) {
+    return {
+        restrict: 'E',
+        templateUrl: 'templates/dropdown.html',
+        scope: {
+            label: '@label',
+            defaultOption: '@defaultOption',
+            availableOptions: '=options',
+            selectedOption: '=selected',
+            onSelection: '&onSelection'
+        },
+        link: function(scope, elem, attrs) {
+            scope.filter = '';
+            scope.open = false;
+
+            scope.onSelect = function(option) {
+                option = option || '';
+                scope.filter = '';
+                scope.open = false;
+
+                // timeout to let ui-bootstrap close dropdown properly
+                $timeout(function() {
+                    scope.onSelection({"option":option});
+                });
+            };
+
+            scope.onInput = function($event) {
+                $event.preventDefault();
+                $event.stopPropagation();
+                scope.open = true;
+            };
+        }
+    };
+}]);

--- a/zmon-controller-ui/styles/forms.css
+++ b/zmon-controller-ui/styles/forms.css
@@ -1,6 +1,6 @@
 .form-control
 {
-    font-size: 16px;
+    font-size: 15px;
     height: auto;
     margin-bottom: 10px;
 }
@@ -183,16 +183,6 @@
 {
     font-size: small;
     margin-top: 5px;
-}
-
-.team-filter-dropdown
-{
-    padding: 10px;
-}
-
-.zmon-controls .team-filter
-{
-    padding-top: 5px;
 }
 
 .parameter

--- a/zmon-controller-ui/styles/main.css
+++ b/zmon-controller-ui/styles/main.css
@@ -986,3 +986,24 @@ body.entities-page .type-col {
     background-color: #8f8f8f !important;
     border: 1px solid #707070 !important;
 }
+
+/***
+ * Dropdown directive
+ */
+
+.dropdown
+{
+    margin-top: 5px;
+}
+
+.dropdown .dropdown-menu
+{
+    padding: 10px;
+}
+
+.dropdown .input-group
+{
+    padding-bottom: 10px;
+}
+
+

--- a/zmon-controller-ui/templates/dropdown.html
+++ b/zmon-controller-ui/templates/dropdown.html
@@ -1,0 +1,23 @@
+<div class="dropdown" is-open="open">
+    <label>{{label}}</label>
+    <a class="dropdown-toggle" ng-if="selectedOption">{{selectedOption}}</a>
+    <a class="dropdown-toggle" ng-if="selectedOption === null">{{defaultOption}}</a>
+    <ul class="dropdown-menu">
+        <li>
+            <div class="input-group">
+                <div class="input-group-btn">
+                    <button class="btn btn-primary">
+                        <i class="fa fa-fw fa-search"></i>
+                    </button>
+                </div>
+                <input type="text" class="form-control" ng-model="filter" ng-click="onInput($event)"/>
+            </div>
+        </li>
+        <li ng-click="onSelect()" ng-if="filter === ''">
+            {{defaultOption}}
+        </li>
+        <li ng-repeat="option in availableOptions | filter: filter" ng-click="onSelect(option)">
+            {{ option }}
+        </li>
+    </ul>
+</div>

--- a/zmon-controller-ui/views/alertDefinitions.html
+++ b/zmon-controller-ui/views/alertDefinitions.html
@@ -15,18 +15,7 @@
             </form>
         </div>
         <div class="col-md-4">
-            <div class="dropdown team-filter">
-                <label>Filter team:</label>
-                <a class="dropdown-toggle">{{ teamFilter && teamFilter !== 'all' ? teamFilter : 'All Teams' }}</a>
-                <ul class="dropdown-menu team-filter-dropdown">
-                    <li ng-hide="teamFilter === null" ng-click="setTeamFilter()">
-                        All Teams
-                    </li>
-                    <li ng-repeat="team in alertTeams" ng-click="setTeamFilter(team)">
-                        {{ team }}
-                    </li>
-                </ul>
-            </div>
+            <dropdown label="Filter team:" options="alertTeams" default-option="All Teams" selected="teamFilter" on-selection="setTeamFilter(option)"></dropdown>
         </div>
     </div>
 </div>

--- a/zmon-controller-ui/views/checkDefinitions.html
+++ b/zmon-controller-ui/views/checkDefinitions.html
@@ -15,18 +15,7 @@
             </form>
         </div>
         <div class="col-md-4">
-            <div class="dropdown team-filter">
-                <label>Filter team:</label>
-                <a class="dropdown-toggle">{{ teamFilter && teamFilter !== 'all' ? teamFilter : 'All Teams' }}</a>
-                <ul class="dropdown-menu team-filter-dropdown">
-                    <li ng-hide="teamFilter === null" ng-click="setTeamFilter()">
-                        All Teams
-                    </li>
-                    <li ng-repeat="team in checkTeams" ng-click="setTeamFilter(team)">
-                        {{ team }}
-                    </li>
-                </ul>
-            </div>
+            <dropdown label="Filter team:" options="checkTeams" default-option="All Teams" selected="teamFilter" on-selection="setTeamFilter(option)"></dropdown>
         </div>
     </div>
 </div>

--- a/zmon-controller-ui/views/entities.html
+++ b/zmon-controller-ui/views/entities.html
@@ -15,18 +15,7 @@
             </form>
         </div>
         <div class="col-md-4">
-            <div class="dropdown team-filter">
-                <label>Filter team:</label>
-                <a class="dropdown-toggle">{{ teamFilter && teamFilter !== 'all' ? teamFilter : 'All Teams' }}</a>
-                <ul class="dropdown-menu team-filter-dropdown">
-                    <li ng-hide="teamFilter === null" ng-click="setTeamFilter()">
-                        All Teams
-                    </li>
-                    <li ng-repeat="team in alertTeams" ng-click="setTeamFilter(team)">
-                        {{ team }}
-                    </li>
-                </ul>
-            </div>
+            <dropdown label="Filter team:" options="alertTeams" default-option="All Teams" selected="teamFilter" on-selection="setTeamFilter(option)"></dropdown>
         </div>
     </div>
 </div>


### PR DESCRIPTION
adds directive that wraps a ui-bootstrap dropdown and adds an input field for filtering

replaces previous HTML on alertDefinitions, checkDefinitions and entities.

localStorage get/set, URL location update and selection of team is still part of the original controllers. This directive just renders HTML and gets a callback for a click event, so functionality on Controllers remains the same.

In the future, directive controller could be extended to use localStorage but for now this is ok.