### PR TITLE
#165 add autofocus directive

### DIFF
--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -163,6 +163,7 @@
 <script src="js/directives/json.js?t=${buildTime}"></script>
 <script src="js/directives/expand.js?t=${buildTime}"></script>
 <script src="js/directives/focus.js?t=${buildTime}"></script>
+<script src="js/directives/autofocus.js?t=${buildTime}"></script>
 <script src="js/directives/commentDialog.js?t=${buildTime}"></script>
 <script src="js/directives/entityFilterContainer.js?t=${buildTime}"></script>
 <script src="js/directives/entityFilterForm.js?t=${buildTime}"></script>

--- a/zmon-controller-ui/js/directives/autofocus.js
+++ b/zmon-controller-ui/js/directives/autofocus.js
@@ -1,9 +1,7 @@
 angular.module('zmon2App').directive('autofocus', function($timeout) {
     return {
         link: function ( scope, element, attrs ) {
-            scope.$watch( attrs.ngFocus, function ( val ) {
-                    $timeout( function () { element[0].focus(); } );
-            }, true);
+            $timeout( function () { element[0].focus(); } );
         }
     };
 });

--- a/zmon-controller-ui/js/directives/autofocus.js
+++ b/zmon-controller-ui/js/directives/autofocus.js
@@ -1,0 +1,9 @@
+angular.module('zmon2App').directive('autofocus', function($timeout) {
+    return {
+        link: function ( scope, element, attrs ) {
+            scope.$watch( attrs.ngFocus, function ( val ) {
+                    $timeout( function () { element[0].focus(); } );
+            }, true);
+        }
+    };
+});

--- a/zmon-controller-ui/views/alertDefinitions.html
+++ b/zmon-controller-ui/views/alertDefinitions.html
@@ -9,7 +9,7 @@
                         <span class="input-group-btn">
                             <button class="btn btn-primary"><i class="fa fa-fw fa-search"></i></button>
                         </span>
-                        <input class="form-control" placeholder="Filter definitions" type="text" ng-model="alertFilter" ng-model-options="{debounce:500}" constant-focus />
+                        <input class="form-control" placeholder="Filter definitions" type="text" ng-model="alertFilter" ng-model-options="{debounce:500}" autofocus />
                     </div>
                 </div>
             </form>

--- a/zmon-controller-ui/views/entities.html
+++ b/zmon-controller-ui/views/entities.html
@@ -9,7 +9,7 @@
                         <span class="input-group-btn">
                             <button class="btn btn-primary"><i class="fa fa-fw fa-search"></i></button>
                         </span>
-                        <input class="form-control" placeholder="Filter entities (key:val)" type="text" ng-model="entityFilter" ng-model-options="{debounce:500}" typeahead="sugg for sugg in filterSuggestions | filter:$viewValue | limitTo:10" constant-focus />
+                        <input class="form-control" placeholder="Filter entities (key:val)" type="text" ng-model="entityFilter" ng-model-options="{debounce:500}" typeahead="sugg for sugg in filterSuggestions | filter:$viewValue | limitTo:10" autofocus />
                     </div>
                 </div>
             </form>


### PR DESCRIPTION
Some browsers focus input fields on load if the attribute 'autofocus' is present. Sadly they only autofocus on load, so somethings focusing is not triggered (like when changing from Check definitions to Alert definitions).

A directive called Autofocus will replace this attribute and force focusing in an angularjs style.

Focusing on the dropdown team filter will be done in a separate issue, after ui-bootstrap has been updated to latest version.