### PR TITLE
Update OpenJDK Docker base image to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-24
+FROM registry.opensource.zalan.do/stups/openjdk:8-26
 
 EXPOSE 8443
 


### PR DESCRIPTION
Update to latest Docker image stups openjdk                   8-26             24m ago stups_stups-go              NO_CVES_FOUND