### PR TITLE
Add team extension to tackle team changes

### DIFF
--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthProperties.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthProperties.java
@@ -16,6 +16,7 @@ public class ZauthProperties {
     private URL teamServiceUrl;
     private URL oauth2AccessTokenUrl;
     private Map<String, List<String>> teamOverlay = Maps.newHashMap();
+    private Map<String, List<String>> teamExtension = Maps.newHashMap();
 
     public Map<String, List<String>> getTeamOverlay() {
         return teamOverlay;
@@ -39,5 +40,13 @@ public class ZauthProperties {
 
     public void setOauth2AccessTokenUrl(URL oauth2AccessTokenUrl) {
         this.oauth2AccessTokenUrl = oauth2AccessTokenUrl;
+    }
+
+    public Map<String, List<String>> getTeamExtension() {
+        return teamExtension;
+    }
+
+    public void setTeamExtension(Map<String, List<String>> teamExtension) {
+        this.teamExtension = teamExtension;
     }
 }

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthTeamService.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthTeamService.java
@@ -17,8 +17,10 @@ import org.zalando.zauth.zmon.config.ZauthProperties;
 import org.zalando.zauth.zmon.domain.Team;
 import org.zalando.zmon.security.TeamService;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Created by hjacobs on 2/4/16.
@@ -65,6 +67,15 @@ public class ZauthTeamService implements TeamService {
             log.info("Adding teams from overlay to {}: {}", username, teams);
             result.addAll(teams);
         }
+
+        Set<String> addByExtension = new TreeSet<>();
+        for(String k : result) {
+            if (zauthProperties.getTeamExtension().containsKey(k)) {
+                List<String> toAdd = zauthProperties.getTeamExtension().get(k);
+                addByExtension.addAll(toAdd);
+            }
+        }
+        result.addAll(addByExtension);
 
         return result;
     }

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthTeamService.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthTeamService.java
@@ -68,13 +68,13 @@ public class ZauthTeamService implements TeamService {
             result.addAll(teams);
         }
 
-        Set<String> addByExtension = new TreeSet<>();
-        for(String k : result) {
-            if (zauthProperties.getTeamExtension().containsKey(k)) {
-                List<String> toAdd = zauthProperties.getTeamExtension().get(k);
-                addByExtension.addAll(toAdd);
-            }
+        final List<String> emptyList = new ArrayList<>(0);
+        final Set<String> addByExtension = new TreeSet<>();
+
+        for (String teamId : result) {
+            addByExtension.addAll(zauthProperties.getTeamExtension().getOrDefault(teamId, emptyList));
         }
+
         result.addAll(addByExtension);
 
         return result;

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthTeamService.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthTeamService.java
@@ -17,10 +17,7 @@ import org.zalando.zauth.zmon.config.ZauthProperties;
 import org.zalando.zauth.zmon.domain.Team;
 import org.zalando.zmon.security.TeamService;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 /**
  * Created by hjacobs on 2/4/16.
@@ -68,11 +65,9 @@ public class ZauthTeamService implements TeamService {
             result.addAll(teams);
         }
 
-        final List<String> emptyList = new ArrayList<>(0);
         final Set<String> addByExtension = new TreeSet<>();
-
         for (String teamId : result) {
-            addByExtension.addAll(zauthProperties.getTeamExtension().getOrDefault(teamId, emptyList));
+            addByExtension.addAll(zauthProperties.getTeamExtension().getOrDefault(teamId, Collections.emptyList()));
         }
 
         result.addAll(addByExtension);


### PR DESCRIPTION
this allows us to add teams based on current team.

If team a splits into b,c we can add a to b and c.