### PR TITLE
Tv token jwt cookie

### DIFF
--- a/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
@@ -1,14 +1,5 @@
 package org.zalando.zmon.controller;
 
-import static java.util.concurrent.TimeUnit.DAYS;
-import static org.zalando.zmon.security.tvtoken.TvTokenService.X_FORWARDED_FOR;
-
-import java.util.UUID;
-
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import com.codahale.metrics.Meter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,10 +13,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.util.WebUtils;
 import org.zalando.zmon.security.tvtoken.TvTokenService;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.DAYS;
+import static org.zalando.zmon.security.tvtoken.TvTokenService.X_FORWARDED_FOR;
+
 /**
- * 
  * @author jbellmann
- *
  */
 @Controller
 public class TvTokenController {
@@ -43,9 +40,9 @@ public class TvTokenController {
 
     @RequestMapping("/tv/{token}")
     public String handleToken(@PathVariable String token,
-            @RequestHeader(name = X_FORWARDED_FOR, required = false) String bindIp,
-            HttpServletRequest request,
-            HttpServletResponse response) {
+                              @RequestHeader(name = X_FORWARDED_FOR, required = false) String bindIp,
+                              HttpServletRequest request,
+                              HttpServletResponse response) {
         if (StringUtils.hasText(token) && token.length() > 5) {
             // check-token
             if (bindIp == null) {
@@ -87,6 +84,8 @@ public class TvTokenController {
         cookie.setComment("ZMON_TV enables access for Team monitors.");
         cookie.setMaxAge((int) DAYS.toSeconds(365));
         cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
         response.addCookie(cookie);
     }
 
@@ -101,6 +100,8 @@ public class TvTokenController {
         cookie.setComment("ZMON_TV_ID enables access for Team monitors.");
         cookie.setMaxAge((int) DAYS.toSeconds(365));
         cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
         response.addCookie(cookie);
     }
 }

--- a/zmon-security-common/src/main/java/org/zalando/zmon/security/jwt/JWTRememberMeServices.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/security/jwt/JWTRememberMeServices.java
@@ -39,4 +39,8 @@ public class JWTRememberMeServices implements ZMonRememberMeServices {
         return ZMonRememberMeServices.super.getOrder() - 20;
     }
 
+    @Override
+    public void autoLoginSuccess(HttpServletRequest request, HttpServletResponse response, Authentication successfulAuthentication) {
+        loginSuccess(request, response, successfulAuthentication);
+    }
 }

--- a/zmon-security-common/src/main/java/org/zalando/zmon/security/jwt/JWTService.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/security/jwt/JWTService.java
@@ -10,11 +10,11 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.RememberMeAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.social.security.SocialAuthenticationToken;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.WebUtils;
@@ -122,8 +122,8 @@ public class JWTService {
     public void writeCookie(HttpServletRequest request, HttpServletResponse response,
                             Authentication successfulAuthentication) {
         Assert.notNull(successfulAuthentication, "'successfullAuthentication' should not be null");
-        Assert.isInstanceOf(SocialAuthenticationToken.class, successfulAuthentication,
-                "'successfullAuthentication' should be an instance of " + SocialAuthenticationToken.class.getName());
+        Assert.isInstanceOf(AbstractAuthenticationToken.class, successfulAuthentication,
+                "'successfullAuthentication' should be an instance of " + AbstractAuthenticationToken.class.getName());
         try {
             String tokenValue = getJwtTokenValue(successfulAuthentication);
             Cookie cookie = new Cookie(COOKIE_NAME, tokenValue);
@@ -154,7 +154,7 @@ public class JWTService {
 
     //@formatter:off
     protected JWTClaimsSet buildClaimSet(Authentication authentication) {
-        final String username = ((SocialAuthenticationToken) authentication).getName();
+        final String username = ((AbstractAuthenticationToken) authentication).getName();
         final String teams = extractTeamsFromAuthentication(authentication);
         final String authority = extractRoleFromAuthentication(authentication);
         log.debug("build claim for {}, with authority : {} and teams : {}", username, authority, teams);

--- a/zmon-security-common/src/main/java/org/zalando/zmon/security/rememberme/ZMonRememberMeServices.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/security/rememberme/ZMonRememberMeServices.java
@@ -39,4 +39,12 @@ public interface ZMonRememberMeServices extends RememberMeServices, Ordered, Log
     @Override
     default void loginFail(HttpServletRequest request, HttpServletResponse response) {
     }
+
+    /**
+     * new callback method to react on successful "autoLogin" call by other RememberMeServices
+     */
+    default void autoLoginSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication successfulAuthentication) {
+
+    }
 }

--- a/zmon-security-common/src/main/java/org/zalando/zmon/security/tvtoken/ZMonTvRememberMeServices.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/security/tvtoken/ZMonTvRememberMeServices.java
@@ -35,7 +35,6 @@ public class ZMonTvRememberMeServices implements ZMonRememberMeServices {
 
     @Override
     public Authentication autoLogin(HttpServletRequest request, HttpServletResponse response) {
-        log.debug("autologin with tvtoken ...");
         Cookie zmonTvToken = WebUtils.getCookie(request, TvTokenService.ZMON_TV);
         Cookie zmonIdToken = WebUtils.getCookie(request, TvTokenService.ZMON_TV_ID);
         if (zmonTvToken != null && zmonIdToken != null) {
@@ -47,7 +46,7 @@ public class ZMonTvRememberMeServices implements ZMonRememberMeServices {
             }
 
             rateLimit.mark();
-            if(rateLimit.getOneMinuteRate()>5) {
+            if (rateLimit.getOneMinuteRate() > 5) {
                 // try not to hit database more than 5/sec for any given token
                 return null;
             }
@@ -65,9 +64,7 @@ public class ZMonTvRememberMeServices implements ZMonRememberMeServices {
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-        log.debug("remove cookies for tvtoken ...");
         tvTokenService.deleteCookiesIfExistent(request, response);
-        log.debug("... cookies removed");
     }
 
 }


### PR DESCRIPTION
Set JWT cookie for TV tokens, too. This prevents hitting the database on every TV token request when not having session stickiness in the load balancer.
