### PR TITLE
#207 set Home dashboard refresh to 1m

### DIFF
--- a/zmon-controller-app/src/main/resources/grafana/home.json
+++ b/zmon-controller-app/src/main/resources/grafana/home.json
@@ -9,6 +9,7 @@
     "timezone": "browser",
     "title": "Grafana ZMON",
     "version": 26,
+    "refresh": "1m",
     "rows": [
       {
         "title": "Welcome",


### PR DESCRIPTION
adds refresh of 1m to Home dashboard

this should initialize the refresh value to 1m and stay like that after changing to other dashboards, although this wasn't tested, because of the lack of dashboards on local environment and the inability to create new ones.