### PR TITLE
Added initial work for mailing onetime tokens

### DIFF
--- a/database/zmon/20_api/05_stored_procedures/60_onetime_access_tokens.sql
+++ b/database/zmon/20_api/05_stored_procedures/60_onetime_access_tokens.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION create_onetime_token(IN "user_name" TEXT, IN "ip" TEXT, IN "token" TEXT, IN "expires_in" INT DEFAULT 365) RETURNS SETOF INT AS
+CREATE OR REPLACE FUNCTION create_onetime_token(IN "user_name" TEXT, IN "ip" TEXT, IN "token" TEXT, IN "expires_in" INT DEFAULT 365) RETURNS SETOF INTEGER AS
 $$
   INSERT INTO zzm_data.onetime_access_token(oat_created_by, oat_created_ip, oat_token, oat_bound_expires) VALUES(user_name, ip, token, NOW() + expires_in * '1 day'::interval) RETURNING oat_id;
 $$

--- a/database/zmon/20_api/05_stored_procedures/60_onetime_access_tokens.sql
+++ b/database/zmon/20_api/05_stored_procedures/60_onetime_access_tokens.sql
@@ -5,7 +5,12 @@ $$
 LANGUAGE 'sql' VOLATILE SECURITY DEFINER
 COST 100;
 
-CREATE OR REPLACE FUNCTION bind_onetime_token(IN token TEXT, IN bind_ip TEXT, IN session_id TEXT) RETURNS SETOF RECORD AS
+CREATE OR REPLACE FUNCTION bind_onetime_token(IN token TEXT, IN bind_ip TEXT, IN session_id TEXT,
+                                                       OUT token TEXT,
+                                                       OUT created TIMESTAMP,
+                                                       OUT bound_at TIMESTAMP,
+                                                       OUT bound_ip TEXT,
+                                                       OUT bound_expires TIMESTAMP) RETURNS SETOF RECORD AS
 $$
   UPDATE zzm_data.onetime_access_token
      SET oat_bound_at = now(),
@@ -15,7 +20,7 @@ $$
      AND (oat_bound_ip is NULL OR oat_bound_ip = bind_ip)
      AND (oat_bound_session_id is NULL or oat_bound_session_id = session_id)
      AND oat_bound_expires IS NULL OR oat_bound_expires > NOW()
-    RETURNING oat_id, oat_token, oat_created, oat_bound_at, oat_bound_ip, oat_bound_expires;
+    RETURNING oat_token, oat_created, oat_bound_at, oat_bound_ip, oat_bound_expires;
 $$
 LANGUAGE 'sql' VOLATILE SECURITY DEFINER;
 
@@ -23,7 +28,8 @@ CREATE OR REPLACE FUNCTION get_onetime_tokens_by_user(IN "user_name" TEXT,
                                                        OUT token TEXT,
                                                        OUT created TIMESTAMP,
                                                        OUT bound_at TIMESTAMP,
-                                                       OUT bound_ip TEXT) RETURNS SETOF RECORD
+                                                       OUT bound_ip TEXT,
+                                                       OUT bound_expires TIMESTAMP) RETURNS SETOF RECORD
 AS
 $$
   SELECT oat_token, oat_created, oat_bound_at, oat_bound_ip, oat_bound_expires

--- a/database/zmon/20_api/05_stored_procedures/60_onetime_access_tokens.sql
+++ b/database/zmon/20_api/05_stored_procedures/60_onetime_access_tokens.sql
@@ -1,11 +1,11 @@
-CREATE OR REPLACE FUNCTION create_onetime_token(IN "user_name" TEXT, IN "ip" TEXT, IN "token" TEXT) RETURNS SETOF INT AS
+CREATE OR REPLACE FUNCTION create_onetime_token(IN "user_name" TEXT, IN "ip" TEXT, IN "token" TEXT, IN "expires_in" INT DEFAULT 365) RETURNS SETOF INT AS
 $$
-  INSERT INTO zzm_data.onetime_access_token(oat_created_by, oat_created_ip, oat_token) VALUES(user_name, ip, token) RETURNING oat_id;
+  INSERT INTO zzm_data.onetime_access_token(oat_created_by, oat_created_ip, oat_token, oat_bound_expires) VALUES(user_name, ip, token, NOW() + expires_in * '1 day'::interval) RETURNING oat_id;
 $$
 LANGUAGE 'sql' VOLATILE SECURITY DEFINER
 COST 100;
 
-CREATE OR REPLACE FUNCTION bind_onetime_token(IN token TEXT, IN bind_ip TEXT, IN session_id TEXT) RETURNS SETOF INT AS
+CREATE OR REPLACE FUNCTION bind_onetime_token(IN token TEXT, IN bind_ip TEXT, IN session_id TEXT) RETURNS SETOF RECORD AS
 $$
   UPDATE zzm_data.onetime_access_token
      SET oat_bound_at = now(),
@@ -14,7 +14,8 @@ $$
    WHERE oat_token = token
      AND (oat_bound_ip is NULL OR oat_bound_ip = bind_ip)
      AND (oat_bound_session_id is NULL or oat_bound_session_id = session_id)
-    RETURNING oat_id;
+     AND oat_bound_expires IS NULL OR oat_bound_expires > NOW()
+    RETURNING oat_id, oat_token, oat_created, oat_bound_at, oat_bound_ip, oat_bound_expires;
 $$
 LANGUAGE 'sql' VOLATILE SECURITY DEFINER;
 
@@ -25,7 +26,7 @@ CREATE OR REPLACE FUNCTION get_onetime_tokens_by_user(IN "user_name" TEXT,
                                                        OUT bound_ip TEXT) RETURNS SETOF RECORD
 AS
 $$
-  SELECT oat_token, oat_created, oat_bound_at, oat_bound_ip
+  SELECT oat_token, oat_created, oat_bound_at, oat_bound_ip, oat_bound_expires
     FROM zzm_data.onetime_access_token
    WHERE oat_created_by = user_name;
 $$ LANGUAGE 'sql' VOLATILE SECURITY DEFINER;

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ! -f zmon-controller-app/target/zmon-controller-1.0.1-SNAPSHOT.jar ]; then
-	./mvnw clean install
+	./mvnw clean install -DskipTests
 fi
 
 echo 'Make sure the provided Vagrant-Box is up and all services are running.'

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/OnetimeTokenInfo.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/OnetimeTokenInfo.java
@@ -23,6 +23,9 @@ public class OnetimeTokenInfo {
     @DatabaseField
     private Date boundAt;
 
+    @DatabaseField
+    private Date boundExpires;
+
     public String getToken() {
         return token;
     }
@@ -53,5 +56,13 @@ public class OnetimeTokenInfo {
 
     public void setBoundAt(Date boundAt) {
         this.boundAt = boundAt;
+    }
+
+    public Date getBoundExpires() {
+        return boundExpires;
+    }
+
+    public void setBoundExpires(Date boundExpires) {
+        this.boundExpires = boundExpires;
     }
 }

--- a/zmon-common/src/main/java/org/zalando/zmon/persistence/OnetimeTokensSProcService.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/persistence/OnetimeTokensSProcService.java
@@ -14,7 +14,7 @@ import org.zalando.zmon.domain.OnetimeTokenInfo;
 @SProcService
 public interface OnetimeTokensSProcService {
     @SProcCall
-    List<Integer> createOnetimeToken(@SProcParam String user, @SProcParam String ip, @SProcParam String token, @SProcParam int expiresInDays);
+    Integer createOnetimeToken(@SProcParam String user, @SProcParam String ip, @SProcParam String token, @SProcParam int expiresInDays);
 
     @SProcCall
     List<OnetimeTokenInfo> bindOnetimeToken(@SProcParam String token, @SProcParam String bindIp, @SProcParam String sessionId);

--- a/zmon-common/src/main/java/org/zalando/zmon/persistence/OnetimeTokensSProcService.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/persistence/OnetimeTokensSProcService.java
@@ -14,10 +14,10 @@ import org.zalando.zmon.domain.OnetimeTokenInfo;
 @SProcService
 public interface OnetimeTokensSProcService {
     @SProcCall
-    List<Integer> createOnetimeToken(@SProcParam String user, @SProcParam String ip, @SProcParam String token);
+    List<Integer> createOnetimeToken(@SProcParam String user, @SProcParam String ip, @SProcParam String token, @SProcParam int expiresInDays);
 
     @SProcCall
-    List<Integer> bindOnetimeToken(@SProcParam String token, @SProcParam String bindIp, @SProcParam String sessionId);
+    List<OnetimeTokenInfo> bindOnetimeToken(@SProcParam String token, @SProcParam String bindIp, @SProcParam String sessionId);
 
     @SProcCall
     List<OnetimeTokenInfo> getOnetimeTokensByUser(@SProcParam String user);

--- a/zmon-controller-app/pom.xml
+++ b/zmon-controller-app/pom.xml
@@ -196,6 +196,11 @@
             <version>1.1.0.Final</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-email</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/api/OneTimeTokenApi.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/api/OneTimeTokenApi.java
@@ -9,12 +9,12 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.zalando.zmon.domain.OnetimeTokenInfo;
 import org.zalando.zmon.exception.ZMonException;
-import org.zalando.zmon.persistence.OnetimeTokensSProcService;
 import org.zalando.zmon.security.permission.DefaultZMonPermissionService;
+import org.zalando.zmon.service.OneTimeTokenService;
+import org.zalando.zmon.service.TokenRequestResult;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.List;
 
 /**
@@ -24,37 +24,33 @@ import java.util.List;
 @RequestMapping("/api/v1/onetime-tokens")
 public class OneTimeTokenApi {
 
-    static final String AB = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    static SecureRandom rnd = new SecureRandom();
-
-    private static String randomString( int len ){
-        StringBuilder sb = new StringBuilder( len );
-        for( int i = 0; i < len; i++ )
-            sb.append( AB.charAt( rnd.nextInt(AB.length()) ) );
-        return sb.toString();
-    }
-
-    @Autowired
-    OnetimeTokensSProcService dbService;
-
-    @Autowired
+    OneTimeTokenService tokenService;
     DefaultZMonPermissionService authService;
+
+    @Autowired
+    public OneTimeTokenApi(OneTimeTokenService tokenService, DefaultZMonPermissionService authService) {
+        this.tokenService = tokenService;
+        this.authService = authService;
+    }
 
     @ResponseBody
     @RequestMapping(value = "", method = RequestMethod.POST)
     public ResponseEntity<String> getNewToken(HttpServletRequest request) throws ZMonException, IOException {
-        String token = randomString(8);
+
+        String token = OneTimeTokenService.randomString(8);
+
         String ipAddress = request.getHeader("X-FORWARDED-FOR");
         if (ipAddress == null) {
             ipAddress = request.getRemoteAddr();
         }
-        int result = dbService.createOnetimeToken(authService.getUserName(), ipAddress, token, 365);
 
-        if (result == -1) {
-            return new ResponseEntity<>("Rate limit hit: wait 15 seconds", HttpStatus.TOO_MANY_REQUESTS);
-        }
-        else if (result > 0) {
-            return new ResponseEntity<>(token, HttpStatus.OK);
+        TokenRequestResult result = tokenService.storeToken(authService.getUserName(), ipAddress, token, 365);
+
+        switch(result) {
+            case RATE_LIMIT_HIT:
+                return new ResponseEntity<>("Rate limit hit: wait 15 seconds", HttpStatus.TOO_MANY_REQUESTS);
+            case OK:
+                return new ResponseEntity<>(token, HttpStatus.OK);
         }
 
         return new ResponseEntity<>("Token create failed", HttpStatus.INTERNAL_SERVER_ERROR);
@@ -63,6 +59,6 @@ public class OneTimeTokenApi {
     @ResponseBody
     @RequestMapping(value="", method=RequestMethod.GET)
     public List<OnetimeTokenInfo> getTokensByUser() {
-        return dbService.getOnetimeTokensByUser(authService.getUserName());
+        return tokenService.getTokensByUser(authService.getUserName());
     }
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/api/OneTimeTokenApi.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/api/OneTimeTokenApi.java
@@ -48,9 +48,16 @@ public class OneTimeTokenApi {
         if (ipAddress == null) {
             ipAddress = request.getRemoteAddr();
         }
-        dbService.createOnetimeToken(authService.getUserName(), ipAddress, token, 365);
+        int result = dbService.createOnetimeToken(authService.getUserName(), ipAddress, token, 365);
 
-        return new ResponseEntity<>(token, HttpStatus.OK);
+        if (result == -1) {
+            return new ResponseEntity<>("Rate limit hit: wait 15 seconds", HttpStatus.TOO_MANY_REQUESTS);
+        }
+        else if (result > 0) {
+            return new ResponseEntity<>(token, HttpStatus.OK);
+        }
+
+        return new ResponseEntity<>("Token create failed", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ResponseBody

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/api/OneTimeTokenApi.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/api/OneTimeTokenApi.java
@@ -43,18 +43,12 @@ public class OneTimeTokenApi {
     @ResponseBody
     @RequestMapping(value = "", method = RequestMethod.POST)
     public ResponseEntity<String> getNewToken(HttpServletRequest request) throws ZMonException, IOException {
-        // there seems to be no authorities, but the API config requires proper scopes, so we should be fine
-        //if(!authService.hasOnetimeTokenPrivilege()) {
-        //    return new ResponseEntity<>("", HttpStatus.UNAUTHORIZED);
-        //}
-
         String token = randomString(8);
-
         String ipAddress = request.getHeader("X-FORWARDED-FOR");
         if (ipAddress == null) {
             ipAddress = request.getRemoteAddr();
         }
-        dbService.createOnetimeToken(authService.getUserName(), ipAddress, token);
+        dbService.createOnetimeToken(authService.getUserName(), ipAddress, token, 365);
 
         return new ResponseEntity<>(token, HttpStatus.OK);
     }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/ControllerProperties.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/ControllerProperties.java
@@ -12,7 +12,7 @@ public class ControllerProperties {
     public int grafanaMinInterval;
 
     public boolean emailTokenEnabled = false;
-    public String emailTokenDomain = "example.com";
+    public String emailTokenDomain = "@example.com";
     public String emailTokenFrom = "zmon@example.com";
     public String emailUserName = "";
     public String emailPassword = "";

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/ControllerProperties.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/ControllerProperties.java
@@ -19,7 +19,7 @@ public class ControllerProperties {
     public String emailHost = "";
     public String emailLoginLink = "https://demo.zmon.io/tv";
     public int emailTokenLength = 15;
-    public int emailPort = 0;
+    public int emailPort = 465;
 
     public String getStaticUrl() {
         return staticUrl;

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/ControllerProperties.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/ControllerProperties.java
@@ -11,6 +11,16 @@ public class ControllerProperties {
     public String staticUrl = "";
     public int grafanaMinInterval;
 
+    public boolean emailTokenEnabled = false;
+    public String emailTokenDomain = "example.com";
+    public String emailTokenFrom = "zmon@example.com";
+    public String emailUserName = "";
+    public String emailPassword = "";
+    public String emailHost = "";
+    public String emailLoginLink = "https://demo.zmon.io/tv";
+    public int emailTokenLength = 15;
+    public int emailPort = 0;
+
     public String getStaticUrl() {
         return staticUrl;
     }
@@ -25,5 +35,77 @@ public class ControllerProperties {
 
     public void setGrafanaMinInterval(int grafanaMinInterval) {
         this.grafanaMinInterval = grafanaMinInterval;
+    }
+
+    public boolean isEmailTokenEnabled() {
+        return emailTokenEnabled;
+    }
+
+    public void setEmailTokenEnabled(boolean emailTokenEnabled) {
+        this.emailTokenEnabled = emailTokenEnabled;
+    }
+
+    public String getEmailTokenDomain() {
+        return emailTokenDomain;
+    }
+
+    public void setEmailTokenDomain(String emailTokenDomain) {
+        this.emailTokenDomain = emailTokenDomain;
+    }
+
+    public String getEmailUserName() {
+        return emailUserName;
+    }
+
+    public void setEmailUserName(String emailUserName) {
+        this.emailUserName = emailUserName;
+    }
+
+    public String getEmailPassword() {
+        return emailPassword;
+    }
+
+    public void setEmailPassword(String emailPassword) {
+        this.emailPassword = emailPassword;
+    }
+
+    public String getEmailHost() {
+        return emailHost;
+    }
+
+    public void setEmailHost(String emailHost) {
+        this.emailHost = emailHost;
+    }
+
+    public int getEmailPort() {
+        return emailPort;
+    }
+
+    public void setEmailPort(int emailPort) {
+        this.emailPort = emailPort;
+    }
+
+    public String getEmailTokenFrom() {
+        return emailTokenFrom;
+    }
+
+    public void setEmailTokenFrom(String emailTokenFrom) {
+        this.emailTokenFrom = emailTokenFrom;
+    }
+
+    public String getEmailLoginLink() {
+        return emailLoginLink;
+    }
+
+    public void setEmailLoginLink(String emailLoginLink) {
+        this.emailLoginLink = emailLoginLink;
+    }
+
+    public int getEmailTokenLength() {
+        return emailTokenLength;
+    }
+
+    public void setEmailTokenLength(int emailTokenLength) {
+        this.emailTokenLength = emailTokenLength;
     }
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
@@ -52,6 +52,7 @@ public class TvTokenController {
     @RequestMapping("/tv/by-email")
     public String getEmailForm(Model model) {
         model.addAttribute("domain", config.getEmailTokenDomain());
+        model.addAttribute("staticUrl", config.getStaticUrl());
         return "by-email";
     }
 

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
@@ -44,7 +44,7 @@ public class TvTokenController {
     }
 
     @RequestMapping("/tv/by-email/{mail:[a-z][a-z\\.]+}")
-    public ResponseEntity<String> getByEMail(@PathVariable String mail,
+    public ResponseEntity<String> getByEMail(@PathVariable(value="mail") String mail,
                                              @RequestHeader(name = X_FORWARDED_FOR, required = false) String bindIp,
                                              HttpServletRequest request) {
         if(mail == null || "".equals(mail) || mail.contains("@") || mail.contains("%40")) {
@@ -58,14 +58,14 @@ public class TvTokenController {
         try {
             boolean sent = oneTimeTokenService.sendByEmail(mail, bindIp);
             if (sent) {
-                return new ResponseEntity<>("SENT_SUCCESSFULL", HttpStatus.OK);
+                return new ResponseEntity<>("SENT_SUCCESSFULLY", HttpStatus.OK);
             }
         }
         catch(Throwable t) {
             log.error("Error during mail send: email={} ip={}", mail, bindIp);
         }
 
-        return new ResponseEntity<>("SENT_FAILED", HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>("SEND_FAILED", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @RequestMapping("/tv/{token}")

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
@@ -58,7 +58,7 @@ public class TvTokenController {
     /* we allow only one request every 15 sec to get through, another global limit is in the DB */
     private boolean isRateLimitHit() {long time = System.currentTimeMillis();
         long lastTime = lastRequest.get();
-        if (time - lastTime < 15) {
+        if (time - lastTime < 15000) {
             return true;
         }
 

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/MailService.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/MailService.java
@@ -1,0 +1,48 @@
+package org.zalando.zmon.service;
+
+import org.apache.commons.mail.DefaultAuthenticator;
+import org.apache.commons.mail.Email;
+import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail.SimpleEmail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.zalando.zmon.config.ControllerProperties;
+
+/**
+ * Created by jmussler on 08.07.16.
+ */
+@Component
+public class MailService {
+
+    private final ControllerProperties config;
+
+    private final Logger log = LoggerFactory.getLogger(MailService.class);
+
+    @Autowired
+    public MailService(ControllerProperties config) {
+        this.config = config;
+    }
+
+    public boolean sendTokenEmail(String token, String emailAdress) {
+        try {
+            Email email = new SimpleEmail();
+            email.setHostName(config.getEmailHost());
+            email.setSmtpPort(config.getEmailPort());
+            email.setAuthenticator(new DefaultAuthenticator(config.getEmailUserName(), config.getEmailPassword()));
+            email.setSSLOnConnect(true);
+            email.setFrom(config.getEmailTokenFrom());
+            email.setSubject("ZMON LOGIN TOKEN");
+            email.setMsg("Login: " + config.getEmailLoginLink() + "/" + token);
+            email.addTo(emailAdress);
+            email.send();
+
+            return true;
+        }
+        catch(EmailException ex) {
+            log.error("Sending email failed: host={} addr={} msg={}", config.getEmailHost(), emailAdress, ex.getMessage());
+        }
+        return false;
+    }
+}

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/OneTimeTokenService.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/OneTimeTokenService.java
@@ -43,6 +43,7 @@ public class OneTimeTokenService {
 
     public boolean storeNewToken(String userName, String fromIp, String token, int lifeTime) {
         List<Integer> ids = dbService.createOnetimeToken(userName, fromIp, token, lifeTime);
+        LOG.info("ids: {}", ids);
         return ids.size() > 0;
     }
 
@@ -53,14 +54,14 @@ public class OneTimeTokenService {
 
         final String emailAddress = emailPrefix + controllerProperties.emailTokenDomain;
         final String token = randomString(controllerProperties.getEmailTokenLength());
-        LOG.info("Sending token: email={} token={}...", emailAddress, token.substring(3));
+        LOG.info("Sending token: email={} token={}...", emailAddress, token.substring(0, 3));
 
         if (!storeNewToken("EMAIL_REQUEST", ip, token, 1)) {
+            LOG.error("Could not store token in PostgreSQL");
             return false;
         }
 
         try {
-
             Email email = new SimpleEmail();
             email.setHostName(controllerProperties.getEmailHost());
             email.setSmtpPort(controllerProperties.getEmailPort());

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/OneTimeTokenService.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/OneTimeTokenService.java
@@ -1,0 +1,83 @@
+package org.zalando.zmon.service;
+
+import org.apache.commons.mail.DefaultAuthenticator;
+import org.apache.commons.mail.Email;
+import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail.SimpleEmail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.zalando.zmon.config.ControllerProperties;
+import org.zalando.zmon.persistence.OnetimeTokensSProcService;
+
+import java.security.SecureRandom;
+import java.util.List;
+
+/**
+ * Created by jmussler on 03.07.16.
+ */
+@Component
+public class OneTimeTokenService {
+
+    private final static Logger LOG = LoggerFactory.getLogger(OneTimeTokenService.class);
+
+    static final String AB = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    static SecureRandom rnd = new SecureRandom();
+
+    private static String randomString( int len ){
+        StringBuilder sb = new StringBuilder( len );
+        for( int i = 0; i < len; i++ )
+            sb.append( AB.charAt( rnd.nextInt(AB.length()) ) );
+        return sb.toString();
+    }
+
+    OnetimeTokensSProcService dbService;
+    ControllerProperties controllerProperties;
+
+    @Autowired
+    public OneTimeTokenService(OnetimeTokensSProcService dbService, ControllerProperties controllerProperties) {
+        this.dbService = dbService;
+        this.controllerProperties = controllerProperties;
+    }
+
+    public boolean storeNewToken(String userName, String fromIp, String token, int lifeTime) {
+        List<Integer> ids = dbService.createOnetimeToken(userName, fromIp, token, lifeTime);
+        return ids.size() > 0;
+    }
+
+    public boolean sendByEmail(String emailPrefix, String ip) {
+        if (!controllerProperties.emailTokenEnabled) {
+            return false;
+        }
+
+        final String emailAddress = emailPrefix + controllerProperties.emailTokenDomain;
+        final String token = randomString(controllerProperties.getEmailTokenLength());
+        LOG.info("Sending token: email={} token={}...", emailAddress, token.substring(3));
+
+        if (!storeNewToken("EMAIL_REQUEST", ip, token, 1)) {
+            return false;
+        }
+
+        try {
+
+            Email email = new SimpleEmail();
+            email.setHostName(controllerProperties.getEmailHost());
+            email.setSmtpPort(controllerProperties.getEmailPort());
+            email.setAuthenticator(new DefaultAuthenticator(controllerProperties.getEmailUserName(), controllerProperties.getEmailPassword()));
+            email.setSSLOnConnect(true);
+            email.setFrom(controllerProperties.getEmailTokenFrom());
+            email.setSubject("ZMON LOGIN TOKEN");
+            email.setMsg("Login: " + controllerProperties.getEmailLoginLink() + "/" + token);
+            email.addTo(emailAddress);
+            email.send();
+
+            return true;
+        }
+        catch(EmailException ex) {
+            LOG.error("Sending email failed: host={} addr={} msg={}", controllerProperties.getEmailHost(), emailAddress, ex.getMessage());
+        }
+
+        return false;
+    }
+}

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/TokenRequestResult.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/TokenRequestResult.java
@@ -1,0 +1,10 @@
+package org.zalando.zmon.service;
+
+/**
+ * Created by jmussler on 08.07.16.
+ */
+public enum TokenRequestResult {
+    FAILED,
+    OK,
+    RATE_LIMIT_HIT
+}

--- a/zmon-controller-app/src/main/resources/templates/by-email.html
+++ b/zmon-controller-app/src/main/resources/templates/by-email.html
@@ -4,7 +4,7 @@
       xmlns:data="https://github.com/mxab/thymeleaf-extras-data-attribute">
 <body>
 <form method="POST" url="/tv/by-email">
-<p>Request login via E-Mail:</p>
+<p>Request login link via E-Mail:</p>
 E-Mail <input type="text" name="mail">@<label th:text="${domain}"></label><br>
 <input type="submit" value="Send!">
 </form>

--- a/zmon-controller-app/src/main/resources/templates/by-email.html
+++ b/zmon-controller-app/src/main/resources/templates/by-email.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4"
+      xmlns:data="https://github.com/mxab/thymeleaf-extras-data-attribute">
+<body>
+<form method="POST" url="/tv/by-email">
+<p>Request login via E-Mail:</p>
+E-Mail <input type="text" name="mail">@<label th:text="${domain}"></label><br>
+<input type="submit" value="Send!">
+</form>
+</body>
+</html>

--- a/zmon-controller-app/src/main/resources/templates/by-email.html
+++ b/zmon-controller-app/src/main/resources/templates/by-email.html
@@ -5,7 +5,7 @@
 <body>
 <form method="POST" url="/tv/by-email">
 <p>Request login link via E-Mail:</p>
-E-Mail <input type="text" name="mail">@<label th:text="${domain}"></label><br>
+E-Mail <input type="text" name="mail"><label th:text="${domain}"></label><br>
 <input type="submit" value="Send!">
 </form>
 </body>

--- a/zmon-controller-app/src/main/resources/templates/by-email.html
+++ b/zmon-controller-app/src/main/resources/templates/by-email.html
@@ -3,10 +3,25 @@
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4"
       xmlns:data="https://github.com/mxab/thymeleaf-extras-data-attribute">
 <body>
-<form method="POST" url="/tv/by-email">
-<p>Request login link via E-Mail:</p>
-E-Mail <input type="text" name="mail"><label th:text="${domain}"></label><br>
-<input type="submit" value="Send!">
-</form>
+<head>
+    <link rel="stylesheet" type="text/css" th:href="${staticUrl} + '/asset/css/zalando-bootstrap.css?t=@buildTime@'"/>
+    <link rel="stylesheet" type="text/css" th:href="${staticUrl} + '/asset/css/font-awesome.min.css?t=@buildTime@'"/>
+</head>
+<div class="container">
+    <div class="row">
+        <div class="col-md-4 col-md-offset-3">
+            <form method="POST" url="/tv/by-email">
+                <div class="form-group">
+                    <h2>Request ZMON login link</h2>
+                    <div class="input-group">
+                        <input type="text" class="form-control" id="mail" name="mail" placeholder="Email">
+                        <span class="input-group-addon" th:text="${domain}"></span>
+                    </div>
+                </div>
+                <button type="submit" class="btn btn-default">Submit</button>
+            </form>
+        </div>
+    </div>
+</div>
 </body>
 </html>

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mockito;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.zalando.zmon.config.ControllerProperties;
 import org.zalando.zmon.domain.OnetimeTokenInfo;
 import org.zalando.zmon.persistence.OnetimeTokensSProcService;
 import org.zalando.zmon.security.tvtoken.TvTokenService;
@@ -36,7 +37,7 @@ public class TvTokenControllerTest {
         when(oneTimeTokenService.sendByEmail(eq("user.name.more"),eq("192.168.23.12"))).thenReturn(false);
 
         mockMvc = MockMvcBuilders.standaloneSetup(new TvTokenController(new TvTokenService(onetimeTokensSProcService),
-                                                  oneTimeTokenService))
+                                                  oneTimeTokenService, new ControllerProperties()))
                                  .alwaysDo(MockMvcResultHandlers.print()).build();
     }
 
@@ -61,6 +62,7 @@ public class TvTokenControllerTest {
     @Test
     public void invalidEmails() throws Exception {
         // @formatter:off
+        /*
         mockMvc.perform(get("/tv/by-email/user.name@domain.tld")
                 .header("X-FORWARDED-FOR", "192.168.23.12")
                 .cookie(new Cookie("JSESSIONID", "987654321")))
@@ -75,12 +77,14 @@ public class TvTokenControllerTest {
                 .header("X-FORWARDED-FOR", "192.168.23.12")
                 .cookie(new Cookie("JSESSIONID", "987654321")))
                 .andExpect(status().is(302));
+                */
         // @formatter:on
     }
 
     @Test
     public void validEmail() throws Exception {
         // @formatter:off
+        /*
         mockMvc.perform(get("/tv/by-email/user.name")
                 .header("X-FORWARDED-FOR", "192.168.23.12")
                 .cookie(new Cookie("JSESSIONID", "987654321")))
@@ -90,11 +94,11 @@ public class TvTokenControllerTest {
                 .header("X-FORWARDED-FOR", "192.168.23.12")
                 .cookie(new Cookie("JSESSIONID", "987654321")))
                 .andExpect(status().is(500));
-
+*/
         // @formatter:on
 
-        verify(oneTimeTokenService).sendByEmail(eq("user.name"), eq("192.168.23.12"));
-        verify(oneTimeTokenService).sendByEmail(eq("user.name.more"), eq("192.168.23.12"));
+    //    verify(oneTimeTokenService).sendByEmail(eq("user.name"), eq("192.168.23.12"));
+  //      verify(oneTimeTokenService).sendByEmail(eq("user.name.more"), eq("192.168.23.12"));
     }
 
 }

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -62,44 +63,32 @@ public class TvTokenControllerTest {
 
     @Test
     public void invalidEmails() throws Exception {
-        // @formatter:off
-        /*
-        mockMvc.perform(get("/tv/by-email/user.name@domain.tld")
+        mockMvc.perform(post("/tv/by-email")
                 .header("X-FORWARDED-FOR", "192.168.23.12")
-                .cookie(new Cookie("JSESSIONID", "987654321")))
-                .andExpect(status().is(404));
+                .cookie(new Cookie("JSESSIONID", "987654321"))
+                .param("mail", "test@example.com"))
+                .andExpect(status().is(400));
 
-        mockMvc.perform(get("/tv/by-email/user.name%40@domain.tld")
+        mockMvc.perform(post("/tv/by-email")
                 .header("X-FORWARDED-FOR", "192.168.23.12")
-                .cookie(new Cookie("JSESSIONID", "987654321")))
-                .andExpect(status().is(404));
-
-        mockMvc.perform(get("/tv/by-email/")
-                .header("X-FORWARDED-FOR", "192.168.23.12")
-                .cookie(new Cookie("JSESSIONID", "987654321")))
-                .andExpect(status().is(302));
-                */
-        // @formatter:on
+                .cookie(new Cookie("JSESSIONID", "987654321"))
+                .param("mail", "test.summary%40example.com"))
+                .andExpect(status().is(400));
     }
 
     @Test
     public void validEmail() throws Exception {
-        // @formatter:off
-        /*
-        mockMvc.perform(get("/tv/by-email/user.name")
+        mockMvc.perform(post("/tv/by-email")
                 .header("X-FORWARDED-FOR", "192.168.23.12")
-                .cookie(new Cookie("JSESSIONID", "987654321")))
+                .cookie(new Cookie("JSESSIONID", "987654321"))
+                .param("mail","user.name"))
                 .andExpect(status().is(200));
 
-        mockMvc.perform(get("/tv/by-email/user.name.more")
+        // verify rate limit hit
+        mockMvc.perform(post("/tv/by-email")
                 .header("X-FORWARDED-FOR", "192.168.23.12")
-                .cookie(new Cookie("JSESSIONID", "987654321")))
-                .andExpect(status().is(500));
-*/
-        // @formatter:on
-
-    //    verify(oneTimeTokenService).sendByEmail(eq("user.name"), eq("192.168.23.12"));
-  //      verify(oneTimeTokenService).sendByEmail(eq("user.name.more"), eq("192.168.23.12"));
+                .cookie(new Cookie("JSESSIONID", "987654321"))
+                .param("mail","user.name"))
+                .andExpect(status().is(429));
     }
-
 }

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
@@ -21,6 +21,7 @@ import org.zalando.zmon.domain.OnetimeTokenInfo;
 import org.zalando.zmon.persistence.OnetimeTokensSProcService;
 import org.zalando.zmon.security.tvtoken.TvTokenService;
 import org.zalando.zmon.service.OneTimeTokenService;
+import org.zalando.zmon.service.TokenRequestResult;
 
 public class TvTokenControllerTest {
 
@@ -33,8 +34,8 @@ public class TvTokenControllerTest {
         onetimeTokensSProcService = Mockito.mock(OnetimeTokensSProcService.class);
         oneTimeTokenService = Mockito.mock(OneTimeTokenService.class);
 
-        when(oneTimeTokenService.sendByEmail(eq("user.name"),eq("192.168.23.12"))).thenReturn(true);
-        when(oneTimeTokenService.sendByEmail(eq("user.name.more"),eq("192.168.23.12"))).thenReturn(false);
+        when(oneTimeTokenService.sendByEmail(eq("user.name"),eq("192.168.23.12"))).thenReturn(TokenRequestResult.OK);
+        when(oneTimeTokenService.sendByEmail(eq("user.name.more"),eq("192.168.23.12"))).thenReturn(TokenRequestResult.FAILED);
 
         mockMvc = MockMvcBuilders.standaloneSetup(new TvTokenController(new TvTokenService(onetimeTokensSProcService),
                                                   oneTimeTokenService, new ControllerProperties()))

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
@@ -1,10 +1,12 @@
 package org.zalando.zmon.controller;
 
 import static java.util.Collections.singletonList;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import javax.servlet.http.Cookie;
 
@@ -14,26 +16,34 @@ import org.mockito.Mockito;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.zalando.zmon.controller.TvTokenController;
+import org.zalando.zmon.domain.OnetimeTokenInfo;
 import org.zalando.zmon.persistence.OnetimeTokensSProcService;
 import org.zalando.zmon.security.tvtoken.TvTokenService;
+import org.zalando.zmon.service.OneTimeTokenService;
 
 public class TvTokenControllerTest {
 
     private OnetimeTokensSProcService onetimeTokensSProcService;
+    private OneTimeTokenService oneTimeTokenService;
     private MockMvc mockMvc;
 
     @Before
     public void setUp() {
         onetimeTokensSProcService = Mockito.mock(OnetimeTokensSProcService.class);
-        mockMvc = MockMvcBuilders.standaloneSetup(new TvTokenController(new TvTokenService(onetimeTokensSProcService)))
-                .alwaysDo(MockMvcResultHandlers.print()).build();
+        oneTimeTokenService = Mockito.mock(OneTimeTokenService.class);
+
+        when(oneTimeTokenService.sendByEmail(eq("user.name"),eq("192.168.23.12"))).thenReturn(true);
+        when(oneTimeTokenService.sendByEmail(eq("user.name.more"),eq("192.168.23.12"))).thenReturn(false);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new TvTokenController(new TvTokenService(onetimeTokensSProcService),
+                                                  oneTimeTokenService))
+                                 .alwaysDo(MockMvcResultHandlers.print()).build();
     }
 
     @Test
     public void happyCase() throws Exception {
-        when(onetimeTokensSProcService.bindOnetimeToken(Mockito.eq("1234567"), Mockito.eq("192.168.23.12"),
-                Mockito.eq("987654321"))).thenReturn(singletonList(1));
+        when(onetimeTokensSProcService.bindOnetimeToken(eq("1234567"), eq("192.168.23.12"),
+                eq("987654321"))).thenReturn(singletonList(new OnetimeTokenInfo()));
 
         // execute
         // @formatter:off
@@ -44,8 +54,47 @@ public class TvTokenControllerTest {
         // @formatter:on
 
         // verify sproc was invoked with specific parameters
-        verify(onetimeTokensSProcService, Mockito.times(0)).bindOnetimeToken(Mockito.eq("1234567"),
-                Mockito.eq("192.168.23.12"), Mockito.eq("987654321"));
+        verify(onetimeTokensSProcService, Mockito.times(0)).bindOnetimeToken(eq("1234567"),
+                eq("192.168.23.12"), eq("987654321"));
+    }
+
+    @Test
+    public void invalidEmails() throws Exception {
+        // @formatter:off
+        mockMvc.perform(get("/tv/by-email/user.name@domain.tld")
+                .header("X-FORWARDED-FOR", "192.168.23.12")
+                .cookie(new Cookie("JSESSIONID", "987654321")))
+                .andExpect(status().is(404));
+
+        mockMvc.perform(get("/tv/by-email/user.name%40@domain.tld")
+                .header("X-FORWARDED-FOR", "192.168.23.12")
+                .cookie(new Cookie("JSESSIONID", "987654321")))
+                .andExpect(status().is(404));
+
+        mockMvc.perform(get("/tv/by-email/")
+                .header("X-FORWARDED-FOR", "192.168.23.12")
+                .cookie(new Cookie("JSESSIONID", "987654321")))
+                .andExpect(status().is(302));
+        // @formatter:on
+    }
+
+    @Test
+    public void validEmail() throws Exception {
+        // @formatter:off
+        mockMvc.perform(get("/tv/by-email/user.name")
+                .header("X-FORWARDED-FOR", "192.168.23.12")
+                .cookie(new Cookie("JSESSIONID", "987654321")))
+                .andExpect(status().is(200));
+
+        mockMvc.perform(get("/tv/by-email/user.name.more")
+                .header("X-FORWARDED-FOR", "192.168.23.12")
+                .cookie(new Cookie("JSESSIONID", "987654321")))
+                .andExpect(status().is(500));
+
+        // @formatter:on
+
+        verify(oneTimeTokenService).sendByEmail(eq("user.name"), eq("192.168.23.12"));
+        verify(oneTimeTokenService).sendByEmail(eq("user.name.more"), eq("192.168.23.12"));
     }
 
 }

--- a/zmon-controller-ui/test/unit/cloudCtrl.spec.js
+++ b/zmon-controller-ui/test/unit/cloudCtrl.spec.js
@@ -24,16 +24,16 @@ describe('CloudCtrl', function() {
             });
 
             httpBackend = $httpBackend;
-            httpBackend.when('GET', 'rest/entities?query=%7B%22type%22%3A%22application%22%7D')
+            httpBackend.when('POST', 'rest/entities', '{"type":"application"}')
                 .respond([{"id": "a-aaa[aws:00000:xxx]", "type": "application", "region": "region/some-region-1", "created_by": "agent", "application_id": "aaa", "infrastructure_account": "aws:0000000"},{"id": "a-bbb[aws:111111111111:some-region-1]", "type": "application", "region": "some-region-1", "created_by": "agent", "application_id": "bbb", "infrastructure_account": "aws:222222222222"},{"id": "a-ccc[aws:333333333333:some-region-1]", "type": "application", "region": "some-region-1", "created_by": "agent", "application_id": "phoenix-zal-cuweb-live", "infrastructure_account": "aws:333333333333"},{"id": "a-ddd[aws:444444444444:some-region-1]", "type": "application", "region": "some-region-1", "created_by": "agent", "application_id": "ddd", "infrastructure_account": "aws:444444444444"},{"id": "a-eee[aws:6666666666:some-region-1]", "type": "application", "region": "some-region-1", "created_by": "agent", "application_id": "eee", "infrastructure_account": "aws:333333333333"}]);
 
-            httpBackend.when('GET', 'rest/entities?query=%7B%22type%22%3A%22local%22%7D')
+            httpBackend.when('POST', 'rest/entities', '{"type":"local"}')
                 .respond([{"id": "aws-ac[aws:111111111111:some-region-1]", "type": "local", "region": "some-region-1", "created_by": "agent", "account_alias": "111", "infrastructure_account": "aws:111111111111"},{"id": "aws-ac[aws:222222222222:some-region-1]", "type": "local", "region": "some-region-1", "created_by": "agent", "account_alias": "222", "infrastructure_account": "aws:222222222222"},{"id": "aws-ac[aws:333333333333:some-region-1]", "type": "local", "region": "some-region-1", "created_by": "agent", "account_alias": "333", "infrastructure_account": "aws:3333333333"},{"id": "aws-ac[aws:444444444444:region/some-region-1]", "type": "local", "region": "region/some-region-1", "created_by": "agent", "account_alias": "444", "infrastructure_account": "aws:444444444444"},{"id": "aws-ac[aws:555555555555:some-region-1]", "type": "local", "region": "some-region-1", "created_by": "agent", "account_alias": "555", "infrastructure_account": "aws:55555555555"}]);
 
-            httpBackend.when('GET', 'rest/entities?query=%7B%22type%22%3A%22instance%22%7D')
+            httpBackend.when('POST', 'rest/entities', '{"type":"instance"}')
                 .respond([]);
 
-            httpBackend.when('GET', 'rest/entities?query=%7B%22type%22%3A%22elb%22%7D')
+            httpBackend.when('POST', 'rest/entities', '{"type":"elb"}')
                 .respond([]);
         });
    });
@@ -44,38 +44,38 @@ describe('CloudCtrl', function() {
     });
 
     it('should initially have 5 teams and 5 apps', function() {
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22local%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22application%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22instance%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22elb%22%7D');
+        httpBackend.expectPOST('rest/entities', '{"type":"local"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"application"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"instance"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"elb"}');
         httpBackend.flush();
         expect(_.keys(scope.teams).length).toBe(5);
         expect(_.keys(scope.applications).length).toBe(5);
     });
 
     it('should return elbs for a given team', function() {
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22local%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22application%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22instance%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22elb%22%7D');
+        httpBackend.expectPOST('rest/entities', '{"type":"local"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"application"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"instance"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"elb"}');
         httpBackend.flush();
         expect(scope.getPublicElbsByTeam(scope.teams['111'])).toBe(0);
     });
 
     it('should confirm there are teams available', function() {
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22local%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22application%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22instance%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22elb%22%7D');
+        httpBackend.expectPOST('rest/entities', '{"type":"local"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"application"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"instance"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"elb"}');
         httpBackend.flush();
         expect(scope.haveTeams()).toBe(true);
     });
 
     it('should confirm there are no metrics available for a given app', function() {
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22local%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22application%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22instance%22%7D');
-        httpBackend.expectGET('rest/entities?query=%7B%22type%22%3A%22elb%22%7D');
+        httpBackend.expectPOST('rest/entities', '{"type":"local"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"application"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"instance"}');
+        httpBackend.expectPOST('rest/entities', '{"type":"elb"}');
         httpBackend.flush();
         expect(scope.hasMetrics(scope.applications.aaa)).toBe(false);
         expect(scope.notHasMetrics(scope.applications.aaa)).toBe(true);

--- a/zmon-security-common/src/main/java/org/zalando/zmon/security/tvtoken/TvTokenService.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/security/tvtoken/TvTokenService.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.web.util.WebUtils;
+import org.zalando.zmon.domain.OnetimeTokenInfo;
 import org.zalando.zmon.persistence.OnetimeTokensSProcService;
 
 public class TvTokenService {
@@ -32,7 +33,7 @@ public class TvTokenService {
 
     // TODO use sproc
     public boolean isValidToken(String token, String bindIp, String sessionId) {
-        List<Integer> result = oneTimeTokenSProcService.bindOnetimeToken(token, bindIp, sessionId);
+        List<OnetimeTokenInfo> result = oneTimeTokenSProcService.bindOnetimeToken(token, bindIp, sessionId);
         return result.size() > 0 ? true : false;
     }
 


### PR DESCRIPTION
Needs some merge of functionality in the service classes.

Basically you call:
```
https://demo.zmon.io/tv/by-email/user.name
```

And receive a token via e-mail to:
```
user.name@<configured domain>
```
The token must be used within one hour and if bound it lives only for 24h.

Combined with the JWT session this will make it work for max 48h @jbellmann.