### PR TITLE
Added HEAD endpoint to retrieve last modified for check and alerts

### DIFF
--- a/database/zmon/20_api/05_stored_procedures/21_get_alert_last_modified_max.sql
+++ b/database/zmon/20_api/05_stored_procedures/21_get_alert_last_modified_max.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE FUNCTION get_alert_last_modified_max() RETURNS timestamptz AS
+$$
+ select max(adt_last_modified) from zzm_data.alert_definition_tree;
+$$ LANGUAGE 'sql' VOLATILE SECURITY DEFINER;

--- a/database/zmon/20_api/05_stored_procedures/21_get_check_last_modified_max.sql
+++ b/database/zmon/20_api/05_stored_procedures/21_get_check_last_modified_max.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE FUNCTION get_check_last_modified_max() RETURNS timestamptz AS
+$$
+ select max(cd_last_modified) from zzm_data.check_definition;
+$$ LANGUAGE 'sql' VOLATILE SECURITY DEFINER;

--- a/update-schema.sh
+++ b/update-schema.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export PGPASSWORD=postgres
+
+psql -h localhost -p 38088 -U postgres -d local_zmon_db -c "DROP SCHEMA zzm_api CASCADE;"
+
+find "database/zmon/20_api" -name '*.sql' \
+                                   | sort \
+                                   | xargs cat \
+                                   | psql -h localhost -p 38088 -U postgres -d local_zmon_db

--- a/zmon-common/src/main/java/org/zalando/zmon/persistence/AlertDefinitionSProcService.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/persistence/AlertDefinitionSProcService.java
@@ -73,4 +73,7 @@ public interface AlertDefinitionSProcService {
 
     @SProcCall
     List<String> getAllTags();
+
+    @SProcCall
+    Date getAlertLastModifiedMax();
 }

--- a/zmon-common/src/main/java/org/zalando/zmon/persistence/CheckDefinitionSProcService.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/persistence/CheckDefinitionSProcService.java
@@ -46,4 +46,7 @@ public interface CheckDefinitionSProcService {
 
     @SProcCall
     List<Integer> deleteUnusedCheckDefinition(@SProcParam int id, @SProcParam List<String> teams);
+
+    @SProcCall
+    Date getCheckLastModifiedMax();
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/api/AlertDefinitionsApi.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/api/AlertDefinitionsApi.java
@@ -1,8 +1,12 @@
 package org.zalando.zmon.api;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,10 +51,14 @@ public class AlertDefinitionsApi extends AbstractZMonController {
         this.authorityService = Preconditions.checkNotNull(authorityService, "authorityService is null");
     }
 
-    @ResponseBody
     @RequestMapping(method=RequestMethod.HEAD)
-    public Date getMaxLastModified() {
-        return service.getMaxLastModified();
+    public void getMaxLastModified(HttpServletResponse response) {
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        df.setTimeZone(tz);
+
+        Date date = service.getMaxLastModified();
+        response.setHeader("Last-Modified", df.format(date));
     }
 
     @RequestMapping(method = RequestMethod.POST)

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/api/AlertDefinitionsApi.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/api/AlertDefinitionsApi.java
@@ -1,5 +1,6 @@
 package org.zalando.zmon.api;
 
+import java.util.Date;
 import java.util.List;
 
 import javax.validation.Valid;
@@ -44,6 +45,12 @@ public class AlertDefinitionsApi extends AbstractZMonController {
     public AlertDefinitionsApi(final AlertService alertService, final DefaultZMonPermissionService authorityService) {
         this.service = Preconditions.checkNotNull(alertService, "alertService is null");
         this.authorityService = Preconditions.checkNotNull(authorityService, "authorityService is null");
+    }
+
+    @ResponseBody
+    @RequestMapping(method=RequestMethod.HEAD)
+    public Date getMaxLastModified() {
+        return service.getMaxLastModified();
     }
 
     @RequestMapping(method = RequestMethod.POST)

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/api/CheckDefinitionsApi.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/api/CheckDefinitionsApi.java
@@ -2,6 +2,7 @@ package org.zalando.zmon.api;
 
 import com.google.common.base.Preconditions;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import org.slf4j.Logger;
@@ -18,8 +19,12 @@ import org.zalando.zmon.exception.ZMonException;
 import org.zalando.zmon.security.permission.DefaultZMonPermissionService;
 import org.zalando.zmon.service.ZMonService;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.TimeZone;
 
 @Controller
 @RequestMapping("/api/v1/check-definitions")
@@ -35,6 +40,16 @@ public class CheckDefinitionsApi extends AbstractZMonController {
     public CheckDefinitionsApi(final ZMonService zMonService, final DefaultZMonPermissionService authorityService) {
         this.zMonService = Preconditions.checkNotNull(zMonService, "zMonService is null");
         this.authorityService = Preconditions.checkNotNull(authorityService, "authorityService is null");
+    }
+
+    @RequestMapping(method=RequestMethod.HEAD)
+    public void getMaxLastModified(HttpServletResponse response) {
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        df.setTimeZone(tz);
+
+        Date date = zMonService.getMaxCheckDefinitionLastModified();
+        response.setHeader("Last-Modified", df.format(date));
     }
 
     @RequestMapping(method = RequestMethod.POST)

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/AlertService.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/AlertService.java
@@ -1,6 +1,7 @@
 package org.zalando.zmon.service;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -53,4 +54,6 @@ public interface AlertService {
     void cleanAlertState(int alertDefinitionId);
 
     List<String> getAllTags();
+
+    Date getMaxLastModified();
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/ZMonService.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/ZMonService.java
@@ -1,9 +1,6 @@
 package org.zalando.zmon.service;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import javax.annotation.Nullable;
 
@@ -54,4 +51,6 @@ public interface ZMonService {
     CheckChartResult getFilteredLastResults(String checkId, String filter, int limit);
 
     JsonNode getAlertCoverage(JsonNode filter);
+
+    Date getMaxCheckDefinitionLastModified();
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/AlertServiceImpl.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/AlertServiceImpl.java
@@ -476,4 +476,9 @@ public class AlertServiceImpl implements AlertService {
 
         return result;
     }
+
+    @Override
+    public Date getMaxLastModified() {
+        return alertDefinintionSProc.getAlertLastModifiedMax();
+    }
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/ZMonServiceImpl.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/ZMonServiceImpl.java
@@ -512,4 +512,9 @@ public class ZMonServiceImpl implements ZMonService {
             return null;
         }
     }
+
+    @Override
+    public Date getMaxCheckDefinitionLastModified() {
+        return checkDefinitionSProc.getCheckLastModifiedMax();
+    }
 }


### PR DESCRIPTION
This way we can save a lot of full downloads for check and alert definitions all day long if nothing changes.