### PR TITLE
#291 assign authorities based on groups from User Service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-30
+FROM registry.opensource.zalan.do/stups/openjdk:8-34
 
 EXPOSE 8443
 

--- a/zmon-controller-app/src/main/resources/config/application-zauth.yml
+++ b/zmon-controller-app/src/main/resources/config/application-zauth.yml
@@ -14,3 +14,5 @@ tokens:
       scopes: uid
     - token-id: team-service
       scopes: uid
+    - token-id: user-service
+      scopes: uid

--- a/zmon-zauth-integration/pom.xml
+++ b/zmon-zauth-integration/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.zalando.zauth</groupId>
             <artifactId>spring-social-zauth</artifactId>
-            <version>0.10.0</version>
+            <version>0.10.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthAutoConfiguration.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthAutoConfiguration.java
@@ -7,8 +7,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.zalando.stups.tokens.AccessTokens;
+import org.zalando.zauth.zmon.service.ZauthAuthorityService;
 import org.zalando.zauth.zmon.service.ZauthTeamService;
 import org.zalando.zmon.config.ZmonOAuth2Properties;
+import org.zalando.zmon.security.AuthorityService;
 import org.zalando.zmon.security.SigninController;
 import org.zalando.zmon.security.TeamService;
 
@@ -34,10 +36,8 @@ public class ZauthAutoConfiguration {
         return new ZauthTeamService(zauthProperties, accessTokens);
     }
 
-    // this now comes with 'spring-boot-zalando-stups-tokens'
-    // @Bean
-    // public AccessTokens accessTokens() throws URISyntaxException {
-    // return
-    // Tokens.createAccessTokensWithUri(zauthProperties.getOauth2AccessTokenUrl().toURI()).manageToken("team-service").addScope("uid").done().start();
-    // }
+    @Bean
+    public AuthorityService authorityService(TeamService teamService, AccessTokens accessTokens) {
+        return new ZauthAuthorityService(zauthProperties, teamService, accessTokens);
+    }
 }

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthProperties.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthProperties.java
@@ -13,10 +13,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "zmon.zauth")
 public class ZauthProperties {
 
+    private URL userServiceUrl;
     private URL teamServiceUrl;
     private URL oauth2AccessTokenUrl;
     private Map<String, List<String>> teamOverlay = Maps.newHashMap();
     private Map<String, List<String>> teamExtension = Maps.newHashMap();
+
+    private String adminsGroup = "Apps/ZMON/Admins";
+    private String usersGroup = "Apps/ZMON/Users";
 
     public Map<String, List<String>> getTeamOverlay() {
         return teamOverlay;
@@ -24,6 +28,14 @@ public class ZauthProperties {
 
     public void setTeamOverlay(Map<String, List<String>> teamOverlay) {
         this.teamOverlay = teamOverlay;
+    }
+
+    public URL getUserServiceUrl() {
+        return userServiceUrl;
+    }
+
+    public void setUserServiceUrl(URL userServiceUrl) {
+        this.userServiceUrl = userServiceUrl;
     }
 
     public URL getTeamServiceUrl() {
@@ -47,6 +59,23 @@ public class ZauthProperties {
     }
 
     public void setTeamExtension(Map<String, List<String>> teamExtension) {
+
         this.teamExtension = teamExtension;
+    }
+
+    public String getAdminsGroup() {
+        return adminsGroup;
+    }
+
+    public void setAdminsGroup(String adminsGroup) {
+        this.adminsGroup = adminsGroup;
+    }
+
+    public String getUsersGroup() {
+        return usersGroup;
+    }
+
+    public void setUsersGroup(String usersGroup) {
+        this.usersGroup = usersGroup;
     }
 }

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthProperties.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthProperties.java
@@ -1,11 +1,11 @@
 package org.zalando.zauth.zmon.config;
 
+import com.google.common.collect.Maps;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-
-import com.google.common.collect.Maps;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Created by hjacobs on 2/4/16.
@@ -59,7 +59,6 @@ public class ZauthProperties {
     }
 
     public void setTeamExtension(Map<String, List<String>> teamExtension) {
-
         this.teamExtension = teamExtension;
     }
 

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/domain/Group.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/domain/Group.java
@@ -1,0 +1,30 @@
+package org.zalando.zauth.zmon.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by hjacobs on 2/4/16.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Group {
+    private String dn;
+
+    private String name;
+
+    public String getDn() {
+        return dn;
+    }
+
+    public void setDn(String dn) {
+        this.dn = dn;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthAuthorityService.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthAuthorityService.java
@@ -1,0 +1,75 @@
+package org.zalando.zauth.zmon.service;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.zalando.stups.oauth2.spring.client.StupsOAuth2RestTemplate;
+import org.zalando.stups.oauth2.spring.client.StupsTokensAccessTokenProvider;
+import org.zalando.stups.tokens.AccessTokens;
+import org.zalando.zauth.zmon.config.ZauthProperties;
+import org.zalando.zauth.zmon.domain.Group;
+import org.zalando.zmon.security.AuthorityService;
+import org.zalando.zmon.security.TeamService;
+import org.zalando.zmon.security.authority.ZMonAdminAuthority;
+import org.zalando.zmon.security.authority.ZMonAuthority;
+import org.zalando.zmon.security.authority.ZMonUserAuthority;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ZauthAuthorityService implements AuthorityService {
+
+    private final Logger log = LoggerFactory.getLogger(ZauthAuthorityService.class);
+
+    private final ZauthProperties zauthProperties;
+    private final TeamService teamService;
+    private final RestTemplate restTemplate;
+
+    public ZauthAuthorityService(ZauthProperties zauthProperties, TeamService teamService, AccessTokens accessTokens) {
+        Preconditions.checkNotNull(zauthProperties.getUserServiceUrl(), "User Service URL must be set");
+
+        this.zauthProperties = zauthProperties;
+        this.teamService = teamService;
+
+        restTemplate = new StupsOAuth2RestTemplate(new StupsTokensAccessTokenProvider("user-service", accessTokens));
+    }
+
+    private Set<String> getGroups(String username) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(zauthProperties.getUserServiceUrl().toString()).path("/api/employees/" + username + "/groups");
+
+        Group[] groups = restTemplate.getForObject(builder.build().toUri(), Group[].class);
+        return Arrays.asList(groups).stream().map(Group::getName).collect(Collectors.toSet());
+    }
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities(String username) {
+        Set<String> groups = getGroups(username);
+
+        List<ZMonAuthority> result = Lists.newArrayList();
+        ZMonAuthority authority = null;
+        if (groups.contains(zauthProperties.getAdminsGroup())) {
+            authority = new ZMonAdminAuthority(username, ImmutableSet.copyOf(teamService.getTeams(username)));
+        } else if (groups.contains(zauthProperties.getUsersGroup())) {
+            authority = new ZMonUserAuthority(username, ImmutableSet.copyOf(teamService.getTeams(username)));
+        }
+
+        if (authority != null) {
+            result = Lists.newArrayList(authority);
+            log.info("User {} has authority {} and teams {}", username, authority.getAuthority(),
+                    authority.getTeams());
+        }
+
+        return result;
+    }
+}

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthTeamService.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/service/ZauthTeamService.java
@@ -2,7 +2,6 @@ package org.zalando.zauth.zmon.service;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -17,7 +16,10 @@ import org.zalando.zauth.zmon.config.ZauthProperties;
 import org.zalando.zauth.zmon.domain.Team;
 import org.zalando.zmon.security.TeamService;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -53,12 +55,11 @@ public class ZauthTeamService implements TeamService {
         try {
             List<Team> teams = restTemplate.exchange(builder.build().toUri(), HttpMethod.GET, null, TYPE_REF).getBody();
             result = teams.stream().filter(t -> !t.getName().equals("")).map(t -> t.getName()).collect(Collectors.toSet());
-        }
-        catch(RestClientException ex) {
+        } catch (RestClientException ex) {
             log.error("Failed to call team service, no teams for now!", ex);
         }
 
-        if(zauthProperties.getTeamOverlay().containsKey(username)) {
+        if (zauthProperties.getTeamOverlay().containsKey(username)) {
             List<String> teams = zauthProperties.getTeamOverlay().get(username);
             log.info("Adding teams from overlay to {}: {}", username, teams);
             result.addAll(teams);


### PR DESCRIPTION
Fixes #291.

Tested locally with "zauth" profile. Users without a proper group will get kind of a signin redirect loop (authentication failes and it's logged).