### PR TITLE
#289 add value field to alert history and remove User and Content fields

### DIFF
--- a/zmon-controller-ui/js/directives/alertHistory.js
+++ b/zmon-controller-ui/js/directives/alertHistory.js
@@ -7,6 +7,7 @@ angular.module('zmon2App').directive('alertHistory', [ 'CommunicationService', f
         },
         link: function(scope, elem, attrs) {
             scope.history = null;
+            scope.historyFromInEpochSeconds = null;
 
             // History button active
             scope.activeHistoryButton = {
@@ -58,39 +59,6 @@ angular.module('zmon2App').directive('alertHistory', [ 'CommunicationService', f
                         scope.history = scope.history.concat(response);
                     }
                 );
-            };
-
-            scope.historyFromInEpochSeconds = null;
-            /**
-             * Returns the content to be displayed for this type of history entry
-             * "historyType" is one of:   ALERT_{STARTED|ENDED}, ALERT_ENTITY_{STARTED|ENDED}, DOWNTIME_{STARTED|ENDED}, DOWNTIME_SCHEDULED, TRIAL_RUN_SCHEDULED,
-             *                          NEW_ALERT_COMMENT, CHECK_DEFINITION_{CREATED|UPDATED}, ALERT_DEFINITION_{CREATED|UPDATED}
-             * "aattributes" is
-             */
-            scope.getHistoryContent = function(historyType, attributes) {
-                switch (historyType) {
-                    case 'ALERT_STARTED':
-                    case 'ALERT_ENDED':
-                    case 'ALERT_ENTITY_STARTED':
-                    case 'ALERT_ENTITY_ENDED':
-                        return "";
-                    case 'DOWNTIME_STARTED':
-                    case 'DOWNTIME_ENDED':
-                    case 'DOWNTIME_SCHEDULED':
-                    case 'DOWNTIME_REMOVED':
-                        return attributes.comment;
-                    case 'ALERT_COMMENT_CREATED':
-                    case 'ALERT_COMMENT_REMOVED':
-                        return attributes.comment;
-                    case 'CHECK_DEFINITION_CREATED':
-                    case 'CHECK_DEFINITION_UPDATED':
-                        return JSON.stringify(attributes);
-                    case 'ALERT_DEFINITION_CREATED':
-                    case 'ALERT_DEFINITION_UPDATED':
-                        return JSON.stringify(attributes);
-                    default:
-                        return "N/A";
-                }
             };
 
             scope.HSLaFromHistoryEventTypeId = function(eventTypeId) {

--- a/zmon-controller-ui/js/directives/alertValueModal.js
+++ b/zmon-controller-ui/js/directives/alertValueModal.js
@@ -8,6 +8,12 @@ angular.module('zmon2App').directive('alertValueModal', [ '$uibModal', 'APP_CONS
         },
         link: function(scope, elem, attrs) {
 
+            if (typeof scope.value === 'string') {
+                try {
+                    scope.value = JSON.parse(scope.value);
+                } catch(e) {}
+            }
+
             var modalCtrl = function($scope, $uibModalInstance, name, value) {
                 $scope.filter = '';
                 $scope.alert = {

--- a/zmon-controller-ui/templates/alertHistory.html
+++ b/zmon-controller-ui/templates/alertHistory.html
@@ -10,9 +10,8 @@
         <tr>
             <th class="col-sm-2">When</th>
             <th class="col-sm-2">Type</th>
-            <th>User</th>
             <th>Entity</th>
-            <th>Content</th>
+            <th>Value</th>
         </tr>
     </thead>
     <tbody>
@@ -21,9 +20,8 @@
             <td class="text-center">
             <span class="history-tag" style="background-color: hsla({{::HSLaFromHistoryEventTypeId(entry.type_id)}}, 50%, 50%, 1);">{{::entry.type_name}}</span>
             </td>
-            <td>{{::entry.attributes.userName}}</td>
             <td>{{::entry.attributes.entity}}</td>
-            <td>{{::getHistoryContent(entry.type_name, entry.attributes)}} </td>
+            <td>{{::entry.attributes.value}}</td>
         </tr>
     </tbody>
 </table>

--- a/zmon-controller-ui/templates/alertHistory.html
+++ b/zmon-controller-ui/templates/alertHistory.html
@@ -21,7 +21,9 @@
             <span class="history-tag" style="background-color: hsla({{::HSLaFromHistoryEventTypeId(entry.type_id)}}, 50%, 50%, 1);">{{::entry.type_name}}</span>
             </td>
             <td>{{::entry.attributes.entity}}</td>
-            <td>{{::entry.attributes.value}}</td>
+            <td>
+                <div alert-value-modal name="entriy.attributes.entity" value="entry.attributes.value">{{entry.attributes.value}}</div>
+            </td>
         </tr>
     </tbody>
 </table>

--- a/zmon-controller-ui/templates/alertHistory.html
+++ b/zmon-controller-ui/templates/alertHistory.html
@@ -22,7 +22,7 @@
             </td>
             <td>{{::entry.attributes.entity}}</td>
             <td>
-                <div alert-value-modal name="entriy.attributes.entity" value="entry.attributes.value">{{entry.attributes.value}}</div>
+                <div alert-value-modal name="entry.attributes.entity" value="entry.attributes.value">{{entry.attributes.value}}</div>
             </td>
         </tr>
     </tbody>

--- a/zmon-controller-ui/views/alertDetails.html
+++ b/zmon-controller-ui/views/alertDetails.html
@@ -177,7 +177,6 @@
                                             {{entityInstance.result.downtimes | downtimeReasons}}
                                         </div>
                                     </div>
-
                                 </td>
                                 <td>
                                     <div class="ellipsis" expand>{{entityInstance.result.captures}}</div>


### PR DESCRIPTION
Value field will be in most cases a stringified JSON object containing all "value" attributes of the event, for example:

`{"td":0.004593,"worker":"worker01","ts":1.472002343625695E9,"value":"ERROR: Command '['find', '/path/...', '-type', 'd', '-name', '.snapshot', '-prune', '-o', '-type', 'f', '-print', '-quit']' timed out after 2.0 seconds"}`