### PR TITLE
#255 remove alert comments by entity

### DIFF
--- a/zmon-controller-ui/views/alertDetails.html
+++ b/zmon-controller-ui/views/alertDetails.html
@@ -155,9 +155,6 @@
                             <tr ng-repeat="entityInstance in allAlerts | filter:alertDetailsSearch.str | orderBy:sortType:sortOrder track by entityInstance.entity" ng-class="{'danger': entityInstance.isActiveAlert == true, 'active-downtime': entityInstance.isAlertInDowntime == true, 'success': entityInstance.isCheckResult == true}">
                                 <td>
                                     <a href="/grafana/dashboard/db/zmon-check-{{check.id}}-{{ entityInstance.entity }}"><i class="fa fa-fw fa-bar-chart-o"></i></a>
-                                    <a class="clickable" ng-if="userInfo['add-comment']" comment-modal alert-id="alertId" count="commentsCount" entity="entityInstance.entity">
-                                        <i class="fa fa-fw fa-comments-o"></i>
-                                    </a>
                                     <a target="_new" ng-if="entityInstance.entityMeta && entityInstance.entityMeta.type && entityInstance.entityMeta.type == 'instance'" href="https://{{entityInstance.entityMeta.region}}.console.aws.amazon.com/ec2/v2/home?region={{entityInstance.entityMeta.region}}#Instances:search={{entityInstance.entityMeta.aws_id}};sort=Name" title="ip: {{entityInstance.entityMeta.ip}}"><i class="fa fa-fw fa-cloud"></i></a>
                                     <a target="_new" ng-if="entityInstance.entityMeta && entityInstance.entityMeta.type && entityInstance.entityMeta.type == 'elb'" href="https://{{entityInstance.entityMeta.region}}.console.aws.amazon.com/ec2/v2/home?region={{entityInstance.entityMeta.region}}#LoadBalancers:search={{entityInstance.entityMeta.name}}"><i class="fa fa-fw fa-cloud"></i></a>
                                     <input ng-if="userInfo['schedule-downtime']" class="set-downtime-checkbox" type="checkbox" ng-checked="downtimeEntities.indexOf(entityInstance.entity) !== -1" ng-click="toggleAlertForDowntime(entityInstance.entity)">


### PR DESCRIPTION
Solves issue #255, backend fails to add alert comments when an entity id is provided.

I do not consider this feature useful anyways, so best to remove it from the frontend.

Approve if you agree