### PR TITLE
#306 use CTRL+S instead of Alt (problematic for Mac users)

### DIFF
--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -251,7 +251,7 @@
 
             // global search key bindings
             $scope.keyDown = function(e) {
-                // toggle globalSearch on Alt
+                // toggle globalSearch on CTRL+S
                 if (e.keyCode === 83 && e.ctrlKey) {
                     $scope.globalSearchVisible = !$scope.globalSearchVisible;
                     e.stopPropagation();

--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -252,8 +252,10 @@
             // global search key bindings
             $scope.keyDown = function(e) {
                 // toggle globalSearch on Alt
-                if (e.keyCode === 18) {
+                if (e.keyCode === 83 && e.ctrlKey) {
                     $scope.globalSearchVisible = !$scope.globalSearchVisible;
+                    e.stopPropagation();
+                    e.preventDefault();
                 }
                 // close on Esc
                 if (e.keyCode === 27) {


### PR DESCRIPTION
#306: Use CTRL+S instead of ALT key (ALT key is used for regular text input on Mac).