### PR TITLE
Fix null returned if not checks in DB at all

### DIFF
--- a/zmon-controller-app/src/main/resources/db/migration/V4__get_all_check_definitions_update.sql
+++ b/zmon-controller-app/src/main/resources/db/migration/V4__get_all_check_definitions_update.sql
@@ -1,3 +1,5 @@
+-- update to fix return of null if there are no checks at all.
+
 CREATE OR REPLACE FUNCTION get_all_check_definitions(
      IN status              zzm_data.definition_status,
     OUT snapshot_id         text,


### PR DESCRIPTION
If no checks in DB , we return null instead of empty list.

Gives ugly null pointer in scheduler.