### PR TITLE
407 format value percent

### DIFF
--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -234,6 +234,7 @@
 <script th:src="${staticUrl} + '/js/services/DowntimesService.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/services/PreconditionsService.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/services/LoadingIndicatorService.js?t=@buildTime@'"></script>
+<script th:src="${staticUrl} + '/js/services/FormatService.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/controllers/DashboardCtrl.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/controllers/CloudCtrl.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/controllers/CloudEndpointsCtrl.js?t=@buildTime@'"></script>

--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -401,24 +401,6 @@
             $interval(refreshStatus, 15000);
             refreshStatus();
 
-            String.prototype.format = function() {
-                var args = arguments;
-                var i = 0;
-                return this.replace(/\{(\w*)?:?(\.\d*f)?\}/g, function(match, key, format) {
-                    var value = '';
-                    key = (typeof key === 'undefined' || key === '') ? 0 : key;
-                    value = typeof args[i] === 'object' ? args[i][key] : args[key];
-
-                    if (format) {
-                        var fp = format.match(/\.(\d*)f/)[1];
-                        value = parseFloat(value).toFixed(fp);
-                    }
-
-                    i++;
-                    return value;
-                });
-            };
-
             // redirect to end url after successful authentication
             var signinRedirTo = localStorageService.get('signinRedirTo');
             if (signinRedirTo) {

--- a/zmon-controller-ui/js/directives/dashboardWidget.js
+++ b/zmon-controller-ui/js/directives/dashboardWidget.js
@@ -123,6 +123,10 @@ angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService',
                 };
 
                 var getFormatedValue = function(format, value) {
+                    if (!_.isNumber(value)) {
+                        return value;
+                    }
+
                     // extract format value if in {:} enclosing
                     var match = format.match(/\{\:(\.[0-9]f)\}/);
 

--- a/zmon-controller-ui/js/directives/dashboardWidget.js
+++ b/zmon-controller-ui/js/directives/dashboardWidget.js
@@ -1,5 +1,5 @@
-angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService', 'MainAlertService', 'FeedbackMessageService', 'DowntimesService', '$sce', '$timeout', 'APP_CONST',
-    function(CommunicationService, MainAlertService, FeedbackMessageService, DowntimesService, $sce, $timeout, APP_CONST) {
+angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService', 'MainAlertService', 'FeedbackMessageService', 'DowntimesService', 'FormatService', '$sce', '$timeout', 'APP_CONST',
+    function(CommunicationService, MainAlertService, FeedbackMessageService, DowntimesService, FormatService, $sce, $timeout, APP_CONST) {
         return {
             restrict: 'E',
             templateUrl: 'templates/dashboardWidget.html',
@@ -122,21 +122,6 @@ angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService',
                     return r;
                 };
 
-                var getFormatedValue = function(format, value) {
-                    if (!_.isNumber(value)) {
-                        return value;
-                    }
-
-                    // extract format value if in {:} enclosing
-                    var match = format.match(/\{\:(\.[0-9]f)\}/);
-
-                    if (match && match.length) {
-                        format = match[1];
-                    }
-
-                    return d3.format(format)(value);
-                }
-
                 var setWidgetData = function(response) {
 
                     // Make sure repsonse is valid, and if not log to console.
@@ -182,7 +167,7 @@ angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService',
                                 }
 
                                 if ($scope.config.options.format) {
-                                    $scope.maxValue = getFormatedValue($scope.config.options.format, $scope.maxValue);
+                                    $scope.maxValue = FormatService.formatNumber($scope.config.options.format, $scope.maxValue);
                                 } else if(_.isNumber($scope.maxValue)) {
                                     $scope.maxValue = ($scope.maxValue || 0).toFixed(0) / 1
                                 }
@@ -221,7 +206,7 @@ angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService',
                                     $scope.maxValue = _.max($scope.values);
 
                                     if ($scope.config.options.format) {
-                                        $scope.lastValue = parseFloat(getFormatedValue($scope.config.options.format, $scope.lastValue));
+                                        $scope.lastValue = FormatService.formatNumber($scope.config.options.format, $scope.lastValue);
                                     }
                                 }
                                 break;

--- a/zmon-controller-ui/js/directives/dashboardWidget.js
+++ b/zmon-controller-ui/js/directives/dashboardWidget.js
@@ -122,6 +122,17 @@ angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService',
                     return r;
                 };
 
+                var getFormatedValue = function(format, value) {
+                    // extract format value if in {:} enclosing
+                    var match = format.match(/\{\:(\.[0-9]f)\}/);
+
+                    if (match && match.length) {
+                        format = match[1];
+                    }
+
+                    return d3.format(format)(value);
+                }
+
                 var setWidgetData = function(response) {
 
                     // Make sure repsonse is valid, and if not log to console.
@@ -167,7 +178,7 @@ angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService',
                                 }
 
                                 if ($scope.config.options.format) {
-                                    $scope.maxValue = $scope.config.options.format.format($scope.maxValue);
+                                    $scope.maxValue = getFormatedValue($scope.config.options.format, $scope.maxValue);
                                 } else if(_.isNumber($scope.maxValue)) {
                                     $scope.maxValue = ($scope.maxValue || 0).toFixed(0) / 1
                                 }
@@ -206,7 +217,7 @@ angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService',
                                     $scope.maxValue = _.max($scope.values);
 
                                     if ($scope.config.options.format) {
-                                        $scope.lastValue = parseFloat($scope.config.options.format.format($scope.lastValue));
+                                        $scope.lastValue = parseFloat(getFormatedValue($scope.config.options.format, $scope.lastValue));
                                     }
                                 }
                                 break;

--- a/zmon-controller-ui/js/directives/gauge.js
+++ b/zmon-controller-ui/js/directives/gauge.js
@@ -26,6 +26,10 @@ angular.module('zmon2App').directive('gauge', function() {
             }
 
             var getFormatedValue = function(format, value) {
+                if (!_.isNumber(value)) {
+                    return value;
+                }
+
                 // extract format value if in {:} enclosing
                 var match = format.match(/\{\:(\.[0-9]f)\}/);
 

--- a/zmon-controller-ui/js/directives/gauge.js
+++ b/zmon-controller-ui/js/directives/gauge.js
@@ -25,6 +25,17 @@ angular.module('zmon2App').directive('gauge', function() {
                 colors.reverse();
             }
 
+            var getFormatedValue = function(format, value) {
+                // extract format value if in {:} enclosing
+                var match = format.match(/\{\:(\.[0-9]f)\}/);
+
+                if (match && match.length) {
+                    format = match[1];
+                }
+
+                return d3.format(format)(value);
+            }
+
             var refreshGauge = function() {
                 scope.value = scope.value/1 || 0;
                 scope.max = scope.max/1 || 100;
@@ -34,7 +45,7 @@ angular.module('zmon2App').directive('gauge', function() {
                     if (g === null) {
                         g = new JustGage({
                             id: "gauge-" + gaugeId,
-                            value: scope.options.format ? scope.options.format.format(scope.value)/1 : scope.value.toFixed(0)/1,
+                            value: scope.options.format ? getFormatedValue(scope.options.format, scope.value)/1 : scope.value.toFixed(0)/1,
                             min: scope._options.min/1,
                             gaugeColor: '#7f7f7f',
                             max: scope._options.max === null ? scope.max.toFixed(0)/1 : scope._options.max/1,
@@ -64,7 +75,7 @@ angular.module('zmon2App').directive('gauge', function() {
                             g.txtMin.attr('text', scope._options.min.toFixed(0));
                         }
 
-                        g.refresh(scope.options.format ? scope.options.format.format(scope.value)/1 : scope.value.toFixed(0)/1);
+                        g.refresh(scope.options.format ? getFormatedValue(scope.options.format,scope.value)/1 : scope.value.toFixed(0)/1);
                     }
                 } catch (ex) {
                     console.error("ERROR Gauge:", ex);

--- a/zmon-controller-ui/js/directives/gauge.js
+++ b/zmon-controller-ui/js/directives/gauge.js
@@ -1,5 +1,5 @@
 var GAUGE_LAST_ID = 0;
-angular.module('zmon2App').directive('gauge', function() {
+angular.module('zmon2App').directive('gauge', ['FormatService', function(FormatService) {
     return {
         restrict: 'E',
         scope: {
@@ -25,21 +25,6 @@ angular.module('zmon2App').directive('gauge', function() {
                 colors.reverse();
             }
 
-            var getFormatedValue = function(format, value) {
-                if (!_.isNumber(value)) {
-                    return value;
-                }
-
-                // extract format value if in {:} enclosing
-                var match = format.match(/\{\:(\.[0-9]f)\}/);
-
-                if (match && match.length) {
-                    format = match[1];
-                }
-
-                return d3.format(format)(value);
-            }
-
             var refreshGauge = function() {
                 scope.value = scope.value/1 || 0;
                 scope.max = scope.max/1 || 100;
@@ -49,7 +34,7 @@ angular.module('zmon2App').directive('gauge', function() {
                     if (g === null) {
                         g = new JustGage({
                             id: "gauge-" + gaugeId,
-                            value: scope.options.format ? getFormatedValue(scope.options.format, scope.value)/1 : scope.value.toFixed(0)/1,
+                            value: FormatService.formatNumber(scope.options.format, scope.value),
                             min: scope._options.min/1,
                             gaugeColor: '#7f7f7f',
                             max: scope._options.max === null ? scope.max.toFixed(0)/1 : scope._options.max/1,
@@ -79,7 +64,7 @@ angular.module('zmon2App').directive('gauge', function() {
                             g.txtMin.attr('text', scope._options.min.toFixed(0));
                         }
 
-                        g.refresh(scope.options.format ? getFormatedValue(scope.options.format,scope.value)/1 : scope.value.toFixed(0)/1);
+                        g.refresh(FormatService.formatNumber(scope.options.format,scope.value));
                     }
                 } catch (ex) {
                     console.error("ERROR Gauge:", ex);
@@ -105,4 +90,4 @@ angular.module('zmon2App').directive('gauge', function() {
             });
         }
     };
-});
+}]);

--- a/zmon-controller-ui/js/services/FormatService.js
+++ b/zmon-controller-ui/js/services/FormatService.js
@@ -18,8 +18,6 @@ angular.module('zmon2App').factory('FormatService', [ function() {
             option = match[1];
         }
 
-        console.log('=>', option, value, d3.format(option)(value));
-
         return d3.format(option)(value);
     }
 

--- a/zmon-controller-ui/js/services/FormatService.js
+++ b/zmon-controller-ui/js/services/FormatService.js
@@ -1,0 +1,27 @@
+angular.module('zmon2App').factory('FormatService', [ function() {
+    var service = {};
+
+    service.formatNumber = function(option, value) {
+
+        if (!_.isNumber(value)) {
+            return value;
+        }
+
+        if (option === undefined) {
+            return value.toFixed(0)/1
+        }
+
+        // extract format spec if in {:} enclosing
+        var match = option.match(/\{\:(\.[0-9]f)\}/);
+
+        if (match && match.length) {
+            option = match[1];
+        }
+
+        console.log('=>', option, value, d3.format(option)(value));
+
+        return d3.format(option)(value);
+    }
+
+    return service;
+}]);

--- a/zmon-controller-ui/test/karma.config.js
+++ b/zmon-controller-ui/test/karma.config.js
@@ -32,7 +32,8 @@ module.exports = function(config) {
         '../lib/ngclipboard/ngclipboard.min.js',
         '../lib/angular-ui-select/select.min.js',
         '../lib/highlightjs/highlight.pack.min.js',
-        '../lib/angular-highlightjs/angular-highlightjs.min.js',
+        '../lib/angular-highlightjs/angular-highlightjs.min.js'
+        
         '../js/app.js',
         '../js/filters/*.js',
         '../js/services/*.js',

--- a/zmon-controller-ui/test/karma.config.js
+++ b/zmon-controller-ui/test/karma.config.js
@@ -32,8 +32,8 @@ module.exports = function(config) {
         '../lib/ngclipboard/ngclipboard.min.js',
         '../lib/angular-ui-select/select.min.js',
         '../lib/highlightjs/highlight.pack.min.js',
-        '../lib/angular-highlightjs/angular-highlightjs.min.js'
-        
+        '../lib/angular-highlightjs/angular-highlightjs.min.js',
+
         '../js/app.js',
         '../js/filters/*.js',
         '../js/services/*.js',


### PR DESCRIPTION
#407 Replaces old format() used on Value and Gauge dashboard widgets with d3.format(), providing a full subset of Python's string formatting mini-language. (i.e. adds $ and %).