### PR TITLE
Make history filters configurable

### DIFF
--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/ControllerProperties.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/ControllerProperties.java
@@ -2,7 +2,6 @@ package org.zalando.zmon.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/EventLogConfiguration.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/EventLogConfiguration.java
@@ -1,8 +1,20 @@
 package org.zalando.zmon.config;
 
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.zmon.persistence.AlertDefinitionSProcService;
+import org.zalando.zmon.persistence.CheckDefinitionSProcService;
+import org.zalando.zmon.service.HistoryService;
+import org.zalando.zmon.service.impl.HistoryServiceImpl;
 import org.zalando.zmon.service.impl.NoOpEventLog;
 
 /**
@@ -19,4 +31,30 @@ public class EventLogConfiguration {
         return new NoOpEventLog();
     }
 
+    @Bean
+    public RestOperations restOperations(final EventLogProperties config) {
+        return new RestTemplate(getClientHttpRequestFactory(config));
+    }
+
+    private ClientHttpRequestFactory getClientHttpRequestFactory(final EventLogProperties config) {
+        final RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(config.getConnectTimeout())
+                .setConnectionRequestTimeout(config.getRequestConnectTimeout())
+                .setSocketTimeout(config.getSocketTimeout())
+                .build();
+        final CloseableHttpClient client = HttpClientBuilder
+                .create()
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+        return new HttpComponentsClientHttpRequestFactory(client);
+    }
+
+    @Bean
+    @Transactional
+    public HistoryService historyService(final RestOperations restOperations,
+                                         final CheckDefinitionSProcService checkDefinitionSProc,
+                                         final AlertDefinitionSProcService alertDefinitionSProc,
+                                         final EventLogProperties eventLogProperties) {
+        return new HistoryServiceImpl(restOperations, checkDefinitionSProc, alertDefinitionSProc, eventLogProperties);
+    }
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/EventLogConfiguration.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/EventLogConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 import org.zalando.zmon.persistence.AlertDefinitionSProcService;
 import org.zalando.zmon.persistence.CheckDefinitionSProcService;
+import org.zalando.zmon.service.EventLogService;
 import org.zalando.zmon.service.HistoryService;
 import org.zalando.zmon.service.impl.HistoryServiceImpl;
 import org.zalando.zmon.service.impl.NoOpEventLog;
@@ -51,10 +52,9 @@ public class EventLogConfiguration {
 
     @Bean
     @Transactional
-    public HistoryService historyService(final RestOperations restOperations,
-                                         final CheckDefinitionSProcService checkDefinitionSProc,
+    public HistoryService historyService(final CheckDefinitionSProcService checkDefinitionSProc,
                                          final AlertDefinitionSProcService alertDefinitionSProc,
-                                         final EventLogProperties eventLogProperties) {
-        return new HistoryServiceImpl(restOperations, checkDefinitionSProc, alertDefinitionSProc, eventLogProperties);
+                                         final EventLogService eventLog) {
+        return new HistoryServiceImpl(checkDefinitionSProc, alertDefinitionSProc, eventLog);
     }
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/EventLogProperties.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/EventLogProperties.java
@@ -1,16 +1,26 @@
 package org.zalando.zmon.config;
 
+import com.google.common.collect.Lists;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.net.URL;
+import java.util.List;
 
-/**
- * Created by hjacobs on 1/28/16.
- */
 @ConfigurationProperties(prefix = "zmon.eventlog")
 public class EventLogProperties {
 
     private URL url;
+
+    private List<Integer> alertHistoryEventsFilter = Lists.newArrayList();
+
+    private List<Integer> checkHistoryEventsFilter = Lists.newArrayList();
+
+    private int connectTimeout;
+
+    private int requestConnectTimeout;
+
+    private int socketTimeout;
+
 
     public URL getUrl() {
         return url;
@@ -18,5 +28,45 @@ public class EventLogProperties {
 
     public void setUrl(URL url) {
         this.url = url;
+    }
+
+    public List<Integer> getAlertHistoryEventsFilter() {
+        return alertHistoryEventsFilter;
+    }
+
+    public void setAlertHistoryEventsFilter(final List<Integer> alertHistoryEventsFilter) {
+        this.alertHistoryEventsFilter = alertHistoryEventsFilter;
+    }
+
+    public List<Integer> getCheckHistoryEventsFilter() {
+        return checkHistoryEventsFilter;
+    }
+
+    public void setCheckHistoryEventsFilter(final List<Integer> checkHistoryEventsFilter) {
+        this.checkHistoryEventsFilter = checkHistoryEventsFilter;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(final int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getRequestConnectTimeout() {
+        return requestConnectTimeout;
+    }
+
+    public void setRequestConnectTimeout(final int requestConnectTimeout) {
+        this.requestConnectTimeout = requestConnectTimeout;
+    }
+
+    public int getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public void setSocketTimeout(final int socketTimeout) {
+        this.socketTimeout = socketTimeout;
     }
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/EventLogService.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/EventLogService.java
@@ -1,0 +1,14 @@
+package org.zalando.zmon.service;
+
+import org.zalando.zmon.event.Event;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public interface EventLogService {
+    List<Event> getAlertEvents(int alertDefinitionId,
+                               @Nullable Integer limit, @Nullable Long fromMillis, @Nullable Long toMillis);
+
+    List<Event> getCheckEvents(int checkDefinitionId,
+                               @Nullable Integer limit, @Nullable Long fromMillis, @Nullable Long toMillis);
+}

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/EventLogServiceImpl.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/EventLogServiceImpl.java
@@ -19,7 +19,6 @@ import javax.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -147,11 +146,5 @@ public class EventLogServiceImpl implements EventLogService {
         }
 
         return e;
-    }
-
-    private static class AlertEventsResponse extends LinkedList<EventlogEvent> {
-    }
-
-    private static class CheckEventsResponse extends LinkedList<Event> {
     }
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/EventLogServiceImpl.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/EventLogServiceImpl.java
@@ -1,0 +1,157 @@
+package org.zalando.zmon.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestOperations;
+import org.zalando.zmon.config.EventLogProperties;
+import org.zalando.zmon.event.Event;
+import org.zalando.zmon.event.EventlogEvent;
+import org.zalando.zmon.service.EventLogService;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class EventLogServiceImpl implements EventLogService {
+    private final static Logger LOG = LoggerFactory.getLogger(HistoryServiceImpl.class);
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final EventLogProperties eventLogProperties;
+    private final RestOperations restOperations;
+
+    @Autowired
+    private EventLogServiceImpl(final EventLogProperties eventLogProperties, final RestOperations restOperations) {
+        this.eventLogProperties = eventLogProperties;
+        this.restOperations = restOperations;
+    }
+
+    @Override
+    public List<Event> getAlertEvents(final int alertDefinitionId,
+                                      @Nullable final Integer limit,
+                                      @Nullable final Long fromMillis,
+                                      @Nullable final Long toMillis) {
+        final Optional<URI> baseQuery = getBaseQueryUri(limit, fromMillis, toMillis);
+        if (!baseQuery.isPresent()) {
+            return ImmutableList.of();
+        }
+
+        final String typesFilter = eventLogProperties.getAlertHistoryEventsFilter().stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(","));
+
+        final URIBuilder queryBuilder = new URIBuilder(baseQuery.get())
+                .addParameter("types", typesFilter)
+                .addParameter("key", "alertId")
+                .addParameter("value", String.valueOf(alertDefinitionId));
+        try {
+            final URI query = queryBuilder.build();
+            final EventlogEvent[] events = restOperations.getForObject(query, EventlogEvent[].class);
+
+            return Arrays.stream(events).
+                    map(this::convert).
+                    collect(Collectors.toList());
+        } catch (URISyntaxException e) {
+            LOG.error("Failed to query for alert events", e);
+        }
+
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<Event> getCheckEvents(final int checkDefinitionId,
+                                      @Nullable final Integer limit,
+                                      @Nullable final Long fromMillis,
+                                      @Nullable final Long toMillis) {
+        final Optional<URI> baseQuery = getBaseQueryUri(limit, fromMillis, toMillis);
+        if (!baseQuery.isPresent()) {
+            return ImmutableList.of();
+        }
+
+        final String typesFilter = eventLogProperties.getCheckHistoryEventsFilter().stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(","));
+
+        final URIBuilder queryBuilder = new URIBuilder(baseQuery.get())
+                .addParameter("types", typesFilter)
+                .addParameter("key", "checkId")
+                .addParameter("value", String.valueOf(checkDefinitionId));
+        try {
+            final URI query = queryBuilder.build();
+
+            return Arrays.asList(restOperations.getForObject(query, Event[].class));
+        } catch (URISyntaxException e) {
+            LOG.error("Failed to query for check events", e);
+        }
+        return ImmutableList.of();
+    }
+
+
+    private Optional<URI> getBaseQueryUri(final Integer limit, final Long fromMillis, final Long toMillis) {
+        final URIBuilder baseQueryBuilder;
+        try {
+            baseQueryBuilder = new URIBuilder(eventLogProperties.getUrl().toString());
+        } catch (URISyntaxException e) {
+            LOG.error("Invalid event log URI", e);
+            return Optional.empty();
+        }
+
+        if (limit != null) {
+            baseQueryBuilder.addParameter("limit", limit.toString());
+        }
+        if (fromMillis != null) {
+            baseQueryBuilder.addParameter("from", fromMillis.toString());
+        }
+        if (toMillis != null) {
+            baseQueryBuilder.addParameter("to", toMillis.toString());
+        }
+
+        try {
+            return Optional.of(baseQueryBuilder.build());
+        } catch (URISyntaxException e) {
+            LOG.error("Failed to build base query", e);
+        }
+
+        return Optional.empty();
+    }
+
+    private Event convert(EventlogEvent in) {
+        final String typeName = in.getTypeName();
+        final String flowId = in.getFlowId();
+
+        final Event e = new Event();
+        e.setTypeName(typeName);
+        e.setTime(in.getTime());
+        e.setFlowId(flowId);
+        e.setTypeId(in.getTypeId());
+
+        for (Map.Entry<String, JsonNode> ie : in.getAttributes().entrySet()) {
+            try {
+                e.setAttribute(ie.getKey(), mapper.writeValueAsString(ie.getValue()));
+            } catch (JsonProcessingException ex) {
+                LOG.error("Failed to convert event {} of type {}", flowId, typeName, ex);
+            }
+        }
+
+        return e;
+    }
+
+    private static class AlertEventsResponse extends LinkedList<EventlogEvent> {
+    }
+
+    private static class CheckEventsResponse extends LinkedList<Event> {
+    }
+}

--- a/zmon-controller-app/src/main/resources/config/application.yml
+++ b/zmon-controller-app/src/main/resources/config/application.yml
@@ -50,6 +50,12 @@ zmon:
       checkid: 9
     eventlog:
         url: http://localhost:8081/
+        connectTimeout: 30000
+        requestConnectTimeout: 30000
+        socketTimeout: 30000
+        alertHistoryEventsFilter: [212993,212994,212995,212996,212997,212998,213252,213253,213504,213505,213506,213514,213515,213520]
+        checkHistoryEventsFilter: [213254,213255,213256,213257]
+
     kairosdb:
         enabled: true
         kairosdbs:

--- a/zmon-controller-app/src/main/resources/config/application.yml
+++ b/zmon-controller-app/src/main/resources/config/application.yml
@@ -50,8 +50,8 @@ zmon:
       checkid: 9
     eventlog:
         url: http://localhost:8081/
-        connectTimeout: 30000
-        requestConnectTimeout: 30000
+        connectTimeout: 5000
+        requestConnectTimeout: 5000
         socketTimeout: 30000
         alertHistoryEventsFilter: [212993,212994,212995,212996,212997,212998,213252,213253,213504,213505,213506,213514,213515,213520]
         checkHistoryEventsFilter: [213254,213255,213256,213257]

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/service/impl/EventLogServiceImplTest.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/service/impl/EventLogServiceImplTest.java
@@ -1,0 +1,74 @@
+package org.zalando.zmon.service.impl;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.client.RestOperations;
+import org.zalando.zmon.config.EventLogProperties;
+import org.zalando.zmon.event.Event;
+import org.zalando.zmon.event.EventlogEvent;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EventLogServiceImplTest {
+    private static String EVENTLOG_URL = "http://localhost:12345";
+
+    @Mock
+    private EventLogProperties eventLogProperties;
+    @Mock
+    private RestOperations restOperations;
+
+    @InjectMocks
+    private EventLogServiceImpl eventLogService;
+
+    @Before
+    public void setUp() throws Exception {
+        when(eventLogProperties.getAlertHistoryEventsFilter()).thenReturn(Arrays.asList(1, 2, 3));
+        when(eventLogProperties.getCheckHistoryEventsFilter()).thenReturn(Arrays.asList(5, 6, 7));
+        when(eventLogProperties.getUrl()).thenReturn(new URL(EVENTLOG_URL));
+    }
+
+    @Test
+    public void testGetAlertEventsQueriesSpecificAlerts() throws URISyntaxException {
+        final URI query = new URIBuilder(EVENTLOG_URL)
+                .addParameter("limit", "5")
+                .addParameter("from", "1000")
+                .addParameter("to", "2000")
+                .addParameter("types", "1,2,3")
+                .addParameter("key", "alertId")
+                .addParameter("value", "1")
+                .build();
+
+        when(restOperations.getForObject(query, EventlogEvent[].class)).thenReturn(new EventlogEvent[0]);
+        List<Event> events = eventLogService.getAlertEvents(1, 5, new Long(1000), new Long(2000));
+        assertEquals(events.size(), 0);
+    }
+
+    @Test
+    public void testGetAlertEventsQueriesSpecificChecks() throws URISyntaxException {
+        final URI query = new URIBuilder(EVENTLOG_URL)
+                .addParameter("limit", "5")
+                .addParameter("from", "1000")
+                .addParameter("to", "2000")
+                .addParameter("types", "5,6,7")
+                .addParameter("key", "checkId")
+                .addParameter("value", "1")
+                .build();
+
+        when(restOperations.getForObject(query, Event[].class)).thenReturn(new Event[0]);
+        List<Event> events = eventLogService.getCheckEvents(1, 5, new Long(1000), new Long(2000));
+        assertEquals(events.size(), 0);
+    }
+}

--- a/zmon-security-common/src/main/java/org/zalando/zmon/security/service/PresharedTokensResourceServerTokenServices.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/security/service/PresharedTokensResourceServerTokenServices.java
@@ -52,7 +52,7 @@ public class PresharedTokensResourceServerTokenServices implements ResourceServe
 
         Collection<? extends GrantedAuthority> authorities;
 
-        // allow overwritting the authority of the preshared token UID
+        // allow overwriting the authority of the preshared token UID
         final String authority = environment.getProperty(String.format("preshared_tokens.%s.authority", accessToken));
 
         if (authority != null) {


### PR DESCRIPTION
supports #430 

Now communication with eventlog is more configurable and less hardcoded. Current filtered IDs are extracted from the code to application configuration