### PR TITLE
Parameterise Oauth URLs

### DIFF
--- a/zmon-controller-app/src/main/resources/config/application-zauth.yml
+++ b/zmon-controller-app/src/main/resources/config/application-zauth.yml
@@ -4,7 +4,7 @@ zmon:
   oauth2:
     sso:
       credentials-directory-path: ${CREDENTIALS_DIR}
-      token-name: ${CREDENTIALS_TOKEN_NAME}
+      platform-token-name: ${CREDENTIALS_TOKEN_NAME}
       authorize-url: ${SSO_AUTHORIZE_URL}
       access-token-url: ${SSO_ACCESS_TOKEN_URL}
       platform-enabled: ${CREDENTIALS_PLATFORM_ENABLED}

--- a/zmon-security-common/src/main/java/org/zalando/zmon/config/ZmonOAuth2Properties.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/config/ZmonOAuth2Properties.java
@@ -1,6 +1,10 @@
 package org.zalando.zmon.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.annotation.PostConstruct;
+import java.util.Map;
 
 /**
  * 
@@ -14,7 +18,18 @@ public class ZmonOAuth2Properties {
 	private String clientSecret;
 
 	private String authorizeUrl;
-	private String accessTokenUrl;
+    private String accessTokenUrl;
+    /**
+     * additionalParams are propagated to spring-social-zauth and being used there as additional query params for requests
+     * to Oauth endpoints.
+     * The problem of "spring-social-zauth" library is that it uses single map of additionalParams for BOTH calls
+     * to authorize URL AND accessToken URL. That library needs to be fixed in order to support 2 sets of additional
+     * parameters.
+     * Knowing this limitation, a decision was taken to extract additional parameters from authorizeUrl only. Thus, if
+     * "authorizeUrl" is configured as "https://foo.bar/baz?param1=bro&param2=pro" then "param1=bro&param2=pro" part
+     * will be used for additionalParams. Query parameters of accessTokenUrl ARE IGNORED.
+     */
+    private Map<String, String> additionalParams;
 
 	/**
 	 * Path to the directory where credential-files can be found (client.json).
@@ -28,9 +43,30 @@ public class ZmonOAuth2Properties {
 
 	private boolean platformEnabled;
 
-	public String getClientId() {
-		return clientId;
-	}
+    @PostConstruct
+    public void init() {
+        additionalParams = UriComponentsBuilder.fromHttpUrl(authorizeUrl)
+                .build()
+                .getQueryParams()
+                .toSingleValueMap();
+
+        /**
+         * Following URLs are being used by "spring-social-zauth" library which expects only base URLs without
+         * additional query parameters. Thus, all possible query parameters are stripped.
+         *
+         * Problem of "spring-social-zauth" is that it appends "?client-id=" to the URL. Thus, if one provides an URL
+         * like "https://foo.bar/baz?param1=bro", the library will transform it to
+         * "https://foo.bar/baz?param1=bro?client-id=...".
+         *
+         * This hack will be here until "spring-social-zauth" is fixed
+         */
+        authorizeUrl = authorizeUrl.split("\\?")[0];
+        accessTokenUrl = accessTokenUrl.split("\\?")[0];
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
 
 	public void setClientId(String clientId) {
 		this.clientId = clientId;
@@ -84,4 +120,8 @@ public class ZmonOAuth2Properties {
 	public void setPlatformEnabled(final boolean platformEnabled) {
 		this.platformEnabled = platformEnabled;
 	}
+
+    public Map<String, String> getAdditionalParams() {
+        return additionalParams;
+    }
 }

--- a/zmon-security-common/src/test/java/org/zalando/zmon/config/ZmonOAuth2PropertiesTest.java
+++ b/zmon-security-common/src/test/java/org/zalando/zmon/config/ZmonOAuth2PropertiesTest.java
@@ -1,0 +1,37 @@
+package org.zalando.zmon.config;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class ZmonOAuth2PropertiesTest {
+
+    @Test
+    public void testAdditionalParametersParsedFromAuthorizeUrl() {
+        ZmonOAuth2Properties props = new ZmonOAuth2Properties();
+
+        props.setAuthorizeUrl("https://foo.bar/baz?param1=bro&param2=pro");
+        props.setAccessTokenUrl("https://baz.bar/foo?param1=pro1");
+
+        props.init();
+
+        assertThat(props.getAdditionalParams()).containsOnly(entry("param1", "bro"),
+                entry("param2", "pro"));
+    }
+
+
+    @Test
+    public void testAuthorizeUrlAndAccessTokenUrlAreStrippedOfQueryParams() {
+        ZmonOAuth2Properties props = new ZmonOAuth2Properties();
+
+        props.setAuthorizeUrl("https://foo.bar/baz?param1=bro&param2=pro");
+        props.setAccessTokenUrl("https://baz.bar/foo?param1=pro1");
+
+        props.init();
+
+        assertThat(props.getAuthorizeUrl()).isEqualTo("https://foo.bar/baz");
+        assertThat(props.getAccessTokenUrl()).isEqualTo("https://baz.bar/foo");
+    }
+
+}

--- a/zmon-zauth-integration/pom.xml
+++ b/zmon-zauth-integration/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>org.zalando.stups</groupId>
-            <version>1.0.12</version>
+            <version>1.0.19</version>
             <artifactId>stups-spring-oauth2-client</artifactId>
         </dependency>
         <dependency>

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthSocialConfigurer.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthSocialConfigurer.java
@@ -15,6 +15,8 @@ import org.zalando.zauth.zmon.service.ZauthAccountConnectionSignupService;
 import org.zalando.zmon.config.ZmonOAuth2Properties;
 import org.zalando.zmon.security.AuthorityService;
 
+import java.util.Map;
+
 /**
  * @author jbellmann
  */
@@ -64,5 +66,10 @@ public class ZauthSocialConfigurer extends AbstractZAuthSocialConfigurer {
     @Override
     protected String getTokenEndpoint() {
         return zmonOAuth2Properties.getAccessTokenUrl();
+    }
+
+    @Override
+    protected Map<String, String> getCustomParameters() {
+        return zmonOAuth2Properties.getAdditionalParams();
     }
 }


### PR DESCRIPTION
supports #454 

Adds support or parameterisation of Oauth URLs `authorize-url` and `access-token-url`. Now one can include query parameters there.