### PR TITLE
spring boot tracing and jdbc tracing using open tracing tracer

### DIFF
--- a/zmon-controller-app/pom.xml
+++ b/zmon-controller-app/pom.xml
@@ -249,6 +249,37 @@
             <version>0.4.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-web-autoconfigure</artifactId>
+            <version>0.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.uber.jaeger</groupId>
+            <artifactId>jaeger-core</artifactId>
+            <version>0.20.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.brave</groupId>
+            <artifactId>brave-opentracing</artifactId>
+            <version>0.21.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter</groupId>
+            <artifactId>zipkin-sender-okhttp3</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.instana</groupId>
+            <artifactId>instana-java-opentracing</artifactId>
+            <version>0.20.7</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-jdbc</artifactId>
+            <version>0.0.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/ZmonApplication.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/ZmonApplication.java
@@ -1,8 +1,15 @@
 package org.zalando.zmon;
 
+//import com.instana.opentracing.InstanaTracer;
+//import com.instana.opentracing.InstanaTracerFactory;
+import io.opentracing.NoopTracer;
+import io.opentracing.util.GlobalTracer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Bean;
+import com.uber.jaeger.Configuration;
+import com.uber.jaeger.samplers.ProbabilisticSampler;
 
 /**
  * Entry for Zmon.
@@ -12,6 +19,20 @@ import org.springframework.context.annotation.ComponentScan;
 @SpringBootApplication
 @ComponentScan(basePackages = {"org.zalando.zmon"})
 public class ZmonApplication {
+	@Bean
+	public io.opentracing.Tracer jaegerTracer() {
+
+		io.opentracing.Tracer tracer = new Configuration("zmon-controller", new Configuration.SamplerConfiguration(ProbabilisticSampler.TYPE, 1),
+				new Configuration.ReporterConfiguration(true, "compose_localhost_1", 5775, 100, 100))
+				.getTracer();
+
+    	/*return new Configuration("zmon-controller", new Configuration.SamplerConfiguration(ProbabilisticSampler.TYPE, 1),
+        	new Configuration.ReporterConfiguration(true, "compose_localhost_1", 5775, 100, 100))
+        	.getTracer();*/
+    	GlobalTracer.register(tracer);
+
+    	return tracer;
+	}
 
     public static void main(String[] args) throws Exception {
         SpringApplication.run(ZmonApplication.class, args);


### PR DESCRIPTION
Opentracing of spring boot zmon-controller application along with tracing of jdbc calls in the traces. This poc was performed using Jaeger client and overall setup was validated using docker-compose setup given in the parent zmon repository. Attached is a sample trace showing multiple spans. Incase the opentracing backend (Jaeger in this case) is not available then the opentracing library has no impact on the application. Application continues to work with tracing but not reported to the tracer backend.

<img width="1276" alt="screen shot 2017-09-01 at 17 38 39" src="https://user-images.githubusercontent.com/15845016/29978766-c7e31d18-8f42-11e7-83f1-baa44be8a088.png">

Reference Issue#457 for this pull request.
