### PR TITLE
Opentracing jaeger

### DIFF
--- a/zmon-controller-app/pom.xml
+++ b/zmon-controller-app/pom.xml
@@ -249,6 +249,37 @@
             <version>0.4.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-web-autoconfigure</artifactId>
+            <version>0.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.uber.jaeger</groupId>
+            <artifactId>jaeger-core</artifactId>
+            <version>0.20.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.brave</groupId>
+            <artifactId>brave-opentracing</artifactId>
+            <version>0.21.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter</groupId>
+            <artifactId>zipkin-sender-okhttp3</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.instana</groupId>
+            <artifactId>instana-java-opentracing</artifactId>
+            <version>0.20.7</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-jdbc</artifactId>
+            <version>0.0.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/ZmonApplication.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/ZmonApplication.java
@@ -1,8 +1,15 @@
 package org.zalando.zmon;
 
+//import com.instana.opentracing.InstanaTracer;
+//import com.instana.opentracing.InstanaTracerFactory;
+import io.opentracing.NoopTracer;
+import io.opentracing.util.GlobalTracer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Bean;
+import com.uber.jaeger.Configuration;
+import com.uber.jaeger.samplers.ProbabilisticSampler;
 
 /**
  * Entry for Zmon.
@@ -12,6 +19,20 @@ import org.springframework.context.annotation.ComponentScan;
 @SpringBootApplication
 @ComponentScan(basePackages = {"org.zalando.zmon"})
 public class ZmonApplication {
+	@Bean
+	public io.opentracing.Tracer jaegerTracer() {
+
+		io.opentracing.Tracer tracer = new Configuration("zmon-controller", new Configuration.SamplerConfiguration(ProbabilisticSampler.TYPE, 1),
+				new Configuration.ReporterConfiguration(true, "compose_localhost_1", 5775, 100, 100))
+				.getTracer();
+
+    	/*return new Configuration("zmon-controller", new Configuration.SamplerConfiguration(ProbabilisticSampler.TYPE, 1),
+        	new Configuration.ReporterConfiguration(true, "compose_localhost_1", 5775, 100, 100))
+        	.getTracer();*/
+    	GlobalTracer.register(tracer);
+
+    	return tracer;
+	}
 
     public static void main(String[] args) throws Exception {
         SpringApplication.run(ZmonApplication.class, args);

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/ZmonApplication.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/ZmonApplication.java
@@ -22,13 +22,14 @@ public class ZmonApplication {
 	@Bean
 	public io.opentracing.Tracer jaegerTracer() {
 
-		io.opentracing.Tracer tracer = new Configuration("zmon-controller", new Configuration.SamplerConfiguration(ProbabilisticSampler.TYPE, 1),
-				new Configuration.ReporterConfiguration(true, "compose_localhost_1", 5775, 100, 100))
-				.getTracer();
+		Configuration config = Configuration.fromEnv();
+
+		io.opentracing.Tracer tracer = config.getTracer();
 
     	/*return new Configuration("zmon-controller", new Configuration.SamplerConfiguration(ProbabilisticSampler.TYPE, 1),
         	new Configuration.ReporterConfiguration(true, "compose_localhost_1", 5775, 100, 100))
         	.getTracer();*/
+
     	GlobalTracer.register(tracer);
 
     	return tracer;

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/OpentracingConfiguration.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/OpentracingConfiguration.java
@@ -1,0 +1,24 @@
+package org.zalando.zmon.config;
+
+
+import io.opentracing.util.GlobalTracer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Configuration
+@EnableWebMvc
+public class OpentracingConfiguration {
+
+    @Bean
+    public io.opentracing.Tracer jaegerTracer() {
+
+        com.uber.jaeger.Configuration config = com.uber.jaeger.Configuration.fromEnv();
+
+        io.opentracing.Tracer tracer = config.getTracer();
+
+        GlobalTracer.register(tracer);
+
+        return tracer;
+    }
+}


### PR DESCRIPTION
opentracing java instrumentation using jaeger tracer. The configuration is loaded through environment variables.

          JAEGER_SERVICE_NAME: "zmon-notification-service"
          JAEGER_AGENT_HOST: "jaeger"
          JAEGER_AGENT_PORT: 5775
          JAEGER_REPORTER_LOG_SPANS: "true"
          JAEGER_REPORTER_MAX_QUEUE_SIZE: 100
          JAEGER_TAGS: "opentracing=poc"
          JAEGER_REPORTER_FLUSH_INTERVAL: 100
          JAEGER_SAMPLER_TYPE: "probabilistic"
          JAEGER_SAMPLER_PARAM: 1