### PR TITLE
#490 fix dashboard widget latency notification warning (orange border)

### DIFF
--- a/zmon-controller-ui/js/directives/dashboardWidget.js
+++ b/zmon-controller-ui/js/directives/dashboardWidget.js
@@ -235,7 +235,7 @@ angular.module('zmon2App').directive('dashboardWidget', ['CommunicationService',
 
                 var refreshWidgetData = function() {
 
-                    $scope.isOutdated =  new Date() / 1000 - $scope.lastUpdate > 30 ? true : false;
+                    $scope.isOutdated =  new Date() / 1000 - $scope.lastUpdate > 60 ? true : false;
                     alertIds = $scope.config.options.alertIds || $scope.config.alertIds || [];
 
                     // include as alert Ids all alertStyle ids (i.e. "red": [3, 5, 10]);


### PR DESCRIPTION
small fix. Widget's latency notification (yellow border around and red font color) is getting triggered because its set to 30secs and now that is the new polling time. This increases the threshold to 60secs. #490 