### PR TITLE
added UI option to switch to TV mode

### DIFF
--- a/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/controller/TvTokenController.java
@@ -6,13 +6,22 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.Base64Utils;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.util.WebUtils;
+import org.zalando.zauth.zmon.config.ZauthSecurityConfig;
 import org.zalando.zmon.config.ControllerProperties;
+import org.zalando.zmon.security.jwt.JWTService;
+import org.zalando.zmon.security.permission.DefaultZMonPermissionService;
 import org.zalando.zmon.security.tvtoken.TvTokenService;
 import org.zalando.zmon.service.OneTimeTokenService;
 import org.zalando.zmon.service.TokenRequestResult;
@@ -36,17 +45,24 @@ public class TvTokenController {
 
     private final TvTokenService tvTokenService;
     private final OneTimeTokenService oneTimeTokenService;
+    private final DefaultZMonPermissionService authService;
+    private final JWTService jwtService;
 
     private final Meter rateLimit = new Meter();
 
     private final ControllerProperties config;
     private AtomicLong lastRequest = new AtomicLong(0);
 
+
     @Autowired
-    public TvTokenController(TvTokenService tvTokenService, OneTimeTokenService oneTimeTokenService, ControllerProperties config) {
+    public TvTokenController(TvTokenService tvTokenService, OneTimeTokenService oneTimeTokenService,
+                             ControllerProperties config, DefaultZMonPermissionService authService,
+                             JWTService jwtService) {
         this.tvTokenService = tvTokenService;
         this.oneTimeTokenService = oneTimeTokenService;
         this.config = config;
+        this.authService = authService;
+        this.jwtService = jwtService;
     }
 
     @RequestMapping("/tv/by-email")
@@ -57,7 +73,8 @@ public class TvTokenController {
     }
 
     /* we allow only one request every 15 sec to get through, another global limit is in the DB */
-    private boolean isRateLimitHit() {long time = System.currentTimeMillis();
+    private boolean isRateLimitHit() {
+        long time = System.currentTimeMillis();
         long lastTime = lastRequest.get();
         if (time - lastTime < 15000) {
             return true;
@@ -66,11 +83,11 @@ public class TvTokenController {
         return !lastRequest.compareAndSet(lastTime, time);
     }
 
-    @RequestMapping(path="/tv/by-email", method= RequestMethod.POST)
-    public ResponseEntity<String> getByEMail(@RequestParam(value="mail") String mail,
+    @RequestMapping(path = "/tv/by-email", method = RequestMethod.POST)
+    public ResponseEntity<String> getByEMail(@RequestParam(value = "mail") String mail,
                                              @RequestHeader(name = X_FORWARDED_FOR, required = false) String bindIp,
                                              HttpServletRequest request) {
-        if(mail == null || "".equals(mail) || mail.contains("@") || mail.contains("%40")) {
+        if (mail == null || "".equals(mail) || mail.contains("@") || mail.contains("%40")) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
 
@@ -78,18 +95,19 @@ public class TvTokenController {
             bindIp = remoteIp(request);
         }
 
-        if(isRateLimitHit()) {
+        if (isRateLimitHit()) {
             return new ResponseEntity<>("SEND_FAILED_RATE_LIMIT", HttpStatus.TOO_MANY_REQUESTS);
         }
 
         try {
             TokenRequestResult sent = oneTimeTokenService.sendByEmail(mail, bindIp);
-            switch(sent) {
-                case OK: return new ResponseEntity<>("SENT_SUCCESSFULLY", HttpStatus.OK);
-                case RATE_LIMIT_HIT: return new ResponseEntity<>("SEND_FAILED_RATE_LIMIT", HttpStatus.TOO_MANY_REQUESTS);
+            switch (sent) {
+                case OK:
+                    return new ResponseEntity<>("SENT_SUCCESSFULLY", HttpStatus.OK);
+                case RATE_LIMIT_HIT:
+                    return new ResponseEntity<>("SEND_FAILED_RATE_LIMIT", HttpStatus.TOO_MANY_REQUESTS);
             }
-        }
-        catch(Throwable t) {
+        } catch (Throwable t) {
             log.error("Error during mail send: email={} ip={} msg={}", mail, bindIp, t.getMessage());
         }
 
@@ -120,18 +138,43 @@ public class TvTokenController {
         return "redirect:/";
     }
 
-    protected boolean isValidToken(String token, String bindIp, String sessionId) {
+    @RequestMapping("/tv/switch")
+    public String switchToTvMode(@RequestHeader(name = X_FORWARDED_FOR, required = false) String ipAddress,
+                                 HttpServletRequest request,
+                                 HttpServletResponse response) throws Exception {
+        logout(request, response);
+
+        String token = OneTimeTokenService.randomString(8);
+        if (ipAddress == null) {
+            ipAddress = remoteIp(request);
+        }
+
+        final TokenRequestResult result = oneTimeTokenService.storeToken(authService.getUserName(), ipAddress, token, 365);
+        if (result != TokenRequestResult.OK) {
+            throw new TokenStoreException(result);
+        }
+
+        return handleToken(token, ipAddress, request, response);
+    }
+
+    @ExceptionHandler(TokenStoreException.class)
+    public ResponseEntity<String> handleErrors(Exception ex) {
+        log.error("Failed to store token", ex);
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private boolean isValidToken(String token, String bindIp, String sessionId) {
         return tvTokenService.isValidToken(token, bindIp, sessionId);
     }
 
-    public static String remoteIp(HttpServletRequest request) {
+    private static String remoteIp(HttpServletRequest request) {
         if (request != null) {
             return request.getRemoteAddr();
         }
         return "UNKNOWN";
     }
 
-    protected void bindZmonTvCookie(String token, HttpServletRequest request, HttpServletResponse response) {
+    private void bindZmonTvCookie(String token, HttpServletRequest request, HttpServletResponse response) {
         String cookieValue = Base64Utils.encodeToString(token.getBytes());
         Cookie cookie = WebUtils.getCookie(request, TvTokenService.ZMON_TV);
         if (cookie == null) {
@@ -161,5 +204,28 @@ public class TvTokenController {
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         response.addCookie(cookie);
+    }
+
+    private void logout(final HttpServletRequest request, final HttpServletResponse response) {
+        new SecurityContextLogoutHandler().logout(request, response, null);
+        deleteLoginCookies(request, response);
+    }
+
+
+    private void deleteLoginCookies(final HttpServletRequest request, final HttpServletResponse response) {
+        final Cookie cookie = WebUtils.getCookie(request, ZauthSecurityConfig.LOGIN_COOKIE_NAME);
+        if (cookie != null) {
+            cookie.setMaxAge(0);
+            cookie.setValue("");
+            response.addCookie(cookie);
+        }
+
+        jwtService.removeCookie(request, response);
+    }
+
+    private class TokenStoreException extends Exception {
+        TokenStoreException(final TokenRequestResult result) {
+            super("One time token. Result = " + result);
+        }
     }
 }

--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -210,6 +210,7 @@
                         </button>
                         <ul class="dropdown-menu" role="menu">
                             <li><a href="logout" data-test="logout" th:href="@{/logout}">Logout</a></li>
+                            <th:block th:unless="${#strings.startsWith(userName,'ZMON_TV_')}"><li><a href="tv-mode" data-test="tv-mode" th:href="@{/tv/switch}">Switch to TV mode</a></li></th:block>
                         </ul>
                    </span>
                 </div>

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/controller/TvTokenControllerTest.java
@@ -1,16 +1,6 @@
 package org.zalando.zmon.controller;
 
-import static java.util.Collections.singletonList;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import javax.servlet.http.Cookie;
-
+import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -20,9 +10,28 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.zalando.zmon.config.ControllerProperties;
 import org.zalando.zmon.domain.OnetimeTokenInfo;
 import org.zalando.zmon.persistence.OnetimeTokensSProcService;
+import org.zalando.zmon.security.jwt.JWTService;
+import org.zalando.zmon.security.jwt.JWTServiceProperties;
+import org.zalando.zmon.security.permission.DefaultZMonPermissionService;
 import org.zalando.zmon.security.tvtoken.TvTokenService;
 import org.zalando.zmon.service.OneTimeTokenService;
 import org.zalando.zmon.service.TokenRequestResult;
+
+import javax.servlet.http.Cookie;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.zalando.zauth.zmon.config.ZauthSecurityConfig.LOGIN_COOKIE_NAME;
 
 public class TvTokenControllerTest {
 
@@ -32,15 +41,17 @@ public class TvTokenControllerTest {
 
     @Before
     public void setUp() {
-        onetimeTokensSProcService = Mockito.mock(OnetimeTokensSProcService.class);
-        oneTimeTokenService = Mockito.mock(OneTimeTokenService.class);
+        onetimeTokensSProcService = mock(OnetimeTokensSProcService.class);
+        oneTimeTokenService = mock(OneTimeTokenService.class);
+        when(oneTimeTokenService.sendByEmail(eq("user.name"), eq("192.168.23.12"))).thenReturn(TokenRequestResult.OK);
+        when(oneTimeTokenService.sendByEmail(eq("user.name.more"), eq("192.168.23.12"))).thenReturn(TokenRequestResult.FAILED);
 
-        when(oneTimeTokenService.sendByEmail(eq("user.name"),eq("192.168.23.12"))).thenReturn(TokenRequestResult.OK);
-        when(oneTimeTokenService.sendByEmail(eq("user.name.more"),eq("192.168.23.12"))).thenReturn(TokenRequestResult.FAILED);
-
+        final JWTServiceProperties jwtServiceProperties = mock(JWTServiceProperties.class);
+        when(jwtServiceProperties.getSecret()).thenReturn("28PI9q068f2qCbT38hnGX279Wei5YU5n");
         mockMvc = MockMvcBuilders.standaloneSetup(new TvTokenController(new TvTokenService(onetimeTokensSProcService),
-                                                  oneTimeTokenService, new ControllerProperties()))
-                                 .alwaysDo(MockMvcResultHandlers.print()).build();
+                oneTimeTokenService, new ControllerProperties(),
+                mock(DefaultZMonPermissionService.class), new JWTService(jwtServiceProperties)))
+                .alwaysDo(MockMvcResultHandlers.print()).build();
     }
 
     @Test
@@ -81,14 +92,41 @@ public class TvTokenControllerTest {
         mockMvc.perform(post("/tv/by-email")
                 .header("X-FORWARDED-FOR", "192.168.23.12")
                 .cookie(new Cookie("JSESSIONID", "987654321"))
-                .param("mail","user.name"))
+                .param("mail", "user.name"))
                 .andExpect(status().is(200));
 
         // verify rate limit hit
         mockMvc.perform(post("/tv/by-email")
                 .header("X-FORWARDED-FOR", "192.168.23.12")
                 .cookie(new Cookie("JSESSIONID", "987654321"))
-                .param("mail","user.name"))
+                .param("mail", "user.name"))
                 .andExpect(status().is(429));
+    }
+
+    @Test
+    public void testConvertToTvMode() throws Exception {
+        when(oneTimeTokenService.storeToken(anyString(), anyString(), anyString(), anyInt()))
+                .thenReturn(TokenRequestResult.OK);
+        when(onetimeTokensSProcService.bindOnetimeToken(anyString(), anyString(), anyString()))
+                .thenReturn(ImmutableList.of(mock(OnetimeTokenInfo.class)));
+        mockMvc.perform(get("/tv/switch")
+                .header("X-Forwarded-For", "127.0.0.1")
+                .cookie(new Cookie(LOGIN_COOKIE_NAME, "987654321"))
+                .cookie(new Cookie(JWTService.COOKIE_NAME, "foo")))
+                .andExpect(cookie().maxAge(LOGIN_COOKIE_NAME, 0)) // deleted
+                .andExpect(cookie().value(LOGIN_COOKIE_NAME, ""))
+                .andExpect(cookie().maxAge(JWTService.COOKIE_NAME, 0)) // deleted
+                .andExpect(cookie().value(JWTService.COOKIE_NAME, ""))
+                .andExpect(cookie().exists(TvTokenService.ZMON_TV))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    @Test
+    public void testConvertFailureToStoreToken() throws Exception {
+        when(oneTimeTokenService.storeToken(anyString(), anyString(), anyString(), anyInt()))
+                .thenReturn(TokenRequestResult.FAILED);
+        mockMvc.perform(get("/tv/switch")
+                .header("X-Forwarded-For", "127.0.0.1"))
+                .andExpect(status().is5xxServerError());
     }
 }

--- a/zmon-security-common/src/main/java/org/zalando/zmon/security/jwt/JWTService.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/security/jwt/JWTService.java
@@ -48,7 +48,7 @@ public class JWTService {
 
     private static final String AUTHORITY_CLAIM = "authority";
 
-    private static final String COOKIE_NAME = "ZMON_JWT";
+    public static final String COOKIE_NAME = "ZMON_JWT";
 
     private final Logger log = LoggerFactory.getLogger(JWTService.class);
 
@@ -115,6 +115,9 @@ public class JWTService {
             cookie.setMaxAge(0);
             // also overwrite the value to make sure it does not contain a
             // JWT-Token anymore
+            cookie.setPath("/");
+            cookie.setHttpOnly(true);
+            cookie.setSecure(true);
             cookie.setValue("");
             response.addCookie(cookie);
         }

--- a/zmon-security-common/src/main/java/org/zalando/zmon/security/tvtoken/TvTokenService.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/security/tvtoken/TvTokenService.java
@@ -34,7 +34,7 @@ public class TvTokenService {
     // TODO use sproc
     public boolean isValidToken(String token, String bindIp, String sessionId) {
         List<OnetimeTokenInfo> result = oneTimeTokenSProcService.bindOnetimeToken(token, bindIp, sessionId);
-        return result.size() == 1 ? true : false;
+        return result.size() == 1;
     }
 
     public void deleteCookiesIfExistent(HttpServletRequest request, HttpServletResponse response) {

--- a/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthSecurityConfig.java
+++ b/zmon-zauth-integration/src/main/java/org/zalando/zauth/zmon/config/ZauthSecurityConfig.java
@@ -49,6 +49,7 @@ import org.zalando.zmon.security.tvtoken.ZMonTvRememberMeServices;
 public class ZauthSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private static final String LOGIN_PAGE_URL = "/signin";
+    public static final String LOGIN_COOKIE_NAME = "JSESSIONID";
 
     @Autowired
     private AuthorityService authorityService;
@@ -104,7 +105,7 @@ public class ZauthSecurityConfig extends WebSecurityConfigurerAdapter {
         .and()
             .logout()
                 .logoutUrl("/logout")
-                .deleteCookies("JSESSIONID")
+                .deleteCookies(LOGIN_COOKIE_NAME)
                 .logoutSuccessUrl("/signin?logout=yes")
                 .permitAll()
         .and()


### PR DESCRIPTION
This adds a new drop-down menu item "Switch to TV mode" that allows regular users to convert their session into a TV/Wallboard mode.
- It logs out the real user and destroys its cookies;
- Creates a one time TV token
- Binds the current session to that TV token

After switching to TV mode the option to switch is no longer available.