### PR TITLE
fix team membership matching

### DIFF
--- a/zmon-security-common/src/main/java/org/zalando/zmon/security/authority/AbstractZMonAuthority.java
+++ b/zmon-security-common/src/main/java/org/zalando/zmon/security/authority/AbstractZMonAuthority.java
@@ -37,9 +37,14 @@ public abstract class AbstractZMonAuthority implements ZMonAuthority {
             // linear time, but we are not expecting a huge set of teams.
             // If we have a huge set of teams, we should use a Patricia trie
             for (final String userTeam : getTeams()) {
-                final int length = Math.min(userTeam.length(), team.length());
-                if (length >= userTeam.length() && userTeam.regionMatches(true, 0, team, 0, length)) {
+                if (userTeam.toLowerCase().equals(team.toLowerCase())) {
                     return true;
+                }
+                if (team.indexOf(0x2F /* "/" */) >= 0) {
+                    final int length = Math.min(userTeam.length(), team.length());
+                    if (length >= userTeam.length() && userTeam.regionMatches(true, 0, team, 0, length)) {
+                        return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
the old version was doing a prefix match, so a member of team "A" was member of any team beginning with an "A"/"a"

the prefix match is done, when the owning team contains a "/" (backward compatible)