### PR TITLE
fix: setup $locationProvider to use html5mode

### DIFF
--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -143,6 +143,8 @@
     </script>
 
     <link rel="manifest" href="/manifest.json">
+
+    <base href="/">
 </head>
 
 <body ng-class="activePage" ng-keypress="keypress($event)" ng-keydown="keydown($event)">

--- a/zmon-controller-ui/js/app.js
+++ b/zmon-controller-ui/js/app.js
@@ -12,8 +12,10 @@ angular.module('zmon2App', [
     'hljs',
     'ngDebounce'
 ])
-    .config(['$routeProvider', '$compileProvider',
-        function($routeProvider, $compileProvider) {
+    .config(['$routeProvider', '$compileProvider', '$locationProvider',
+        function($routeProvider, $compileProvider, $locationProvider) {
+            $locationProvider.html5Mode({enabled: true});
+
             // Whitelist "blob:" URLs for the anchor "href" to download check-definition YAML file in Trial Runs page
             $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|tel|file|blob):/);
 


### PR DESCRIPTION
documentation about the topic can be found here:
https://docs.angularjs.org/guide/$location#browser-in-html5-mode

should fix the fact that in trial run, whenever a new character is typed in a text area, a trial run page gets added to the browser's history.