### PR TITLE
fix(AlertDetail): display captured exceptions in alert-value-modal

### DIFF
--- a/zmon-controller-ui/views/alertDetails.html
+++ b/zmon-controller-ui/views/alertDetails.html
@@ -199,7 +199,7 @@
                                     </div>
                                 </td>
                                 <td>
-                                    <div class="ellipsis" expand>{{entityInstance.result.captures}}</div>
+                                    <div class="ellipsis" alert-value-modal value="entityInstance.result.captures">{{entityInstance.result.captures}}</div>
                                 </td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
when an alert had caught an exception the value was just dropped raw in the table.

when you click on it now, it gets displayed in a modal