### PR TITLE
add CorsHeadersCleanerInterceptors to strip CORS headers off proxied requests

### DIFF
--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/CorsHeadersCleanerInterceptors.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/CorsHeadersCleanerInterceptors.java
@@ -1,0 +1,28 @@
+package org.zalando.zmon.config;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.AsyncClientHttpRequestExecution;
+import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureAdapter;
+
+import java.io.IOException;
+
+public class CorsHeadersCleanerInterceptors implements AsyncClientHttpRequestInterceptor {
+    @Override
+    public ListenableFuture<ClientHttpResponse> intercept(HttpRequest httpRequest, byte[] bytes, AsyncClientHttpRequestExecution asyncClientHttpRequestExecution) throws IOException {
+        ListenableFuture<ClientHttpResponse> listenableFuture = asyncClientHttpRequestExecution.executeAsync(httpRequest, bytes);
+        return new ListenableFutureAdapter<ClientHttpResponse, ClientHttpResponse>(listenableFuture) {
+            @Override
+            protected ClientHttpResponse adapt(ClientHttpResponse clientHttpResponse) {
+                clientHttpResponse.getHeaders().remove(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
+                clientHttpResponse.getHeaders().remove(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS);
+                clientHttpResponse.getHeaders().remove(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS);
+                clientHttpResponse.getHeaders().remove(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS);
+                return clientHttpResponse;
+            }
+        };
+    }
+}

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/KairosDBConfiguration.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/KairosDBConfiguration.java
@@ -33,6 +33,8 @@ public class KairosDBConfiguration {
         final AsyncRestTemplate restTemplate = new AsyncRestTemplate(new RestAsyncClientHttpRequestFactory(client, executor));
 
         restTemplate.getInterceptors().add(new TracingAsyncRestTemplateInterceptor());
+        // Since we set our own CORS headers (CorsConfiguration), strip them from KairosDB response
+        restTemplate.getInterceptors().add(new CorsHeadersCleanerInterceptors());
 
         return restTemplate;
     }


### PR DESCRIPTION
KairosDB returns CORS headers, which conflicts with CORS headers that `CorsConfiguration` sets on responses. `CorsHeadersCleanerInterceptors` strips CORS headers off proxied responses coming from KairosDB