### PR TITLE
pass query params to grafana6

### DIFF
--- a/zmon-controller-app/src/main/java/org/zalando/zmon/controller/GrafanaUIController.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/controller/GrafanaUIController.java
@@ -86,6 +86,10 @@ public class GrafanaUIController {
     @RequestMapping(value = "/grafana6/**")
     public String grafana6Redirect(HttpServletRequest request) {
         String redirect = controllerProperties.grafanaHost + request.getRequestURI().replace("/grafana6/", "");
+        String query = request.getQueryString();
+        if(null != query) {
+            redirect += "?" + query;
+        }
         return "redirect:" + redirect;
     }
 }

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/controller/GrafanaUIControllerTest.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/controller/GrafanaUIControllerTest.java
@@ -2,6 +2,12 @@ package org.zalando.zmon.controller;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.ui.ExtendedModelMap;
 import org.zalando.zmon.config.AppdynamicsProperties;
 import org.zalando.zmon.config.ControllerProperties;
@@ -9,7 +15,11 @@ import org.zalando.zmon.config.EumTracingProperties;
 import org.zalando.zmon.config.KairosDBProperties;
 
 import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@RunWith(MockitoJUnitRunner.class)
 public class GrafanaUIControllerTest {
 
     @Test
@@ -83,4 +93,23 @@ public class GrafanaUIControllerTest {
 
         Assertions.assertThat(model.get(IndexController.APPDYNAMICS_ENABLED)).isEqualTo(false);
     }
+
+    @Test
+    public void TestGrafana6Redirect() throws Exception {
+        GrafanaUIController controller = new GrafanaUIController(
+                mock(KairosDBProperties.class),
+                mock(ControllerProperties.class),
+                mock(AppdynamicsProperties.class),
+                mock(EumTracingProperties.class)
+        );
+
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(controller).alwaysDo(print()).build();
+
+        MvcResult result = mockMvc.perform(get("/grafana6/db/testing?some-param=some-value")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+        Assertions.assertThat(result.getResponse().getHeader("Location")).contains("/testing?some-param=some-value");
+    }
+
 }


### PR DESCRIPTION
query parameters (eg template variables) are not passed to grafana 6 in redirect