### PR TITLE
add grafana_mapping table that has mappings to Grafana dashboard uid

### DIFF
--- a/database/zmon/10_data/04_tables/80_grafana_mapping.sql
+++ b/database/zmon/10_data/04_tables/80_grafana_mapping.sql
@@ -1,0 +1,5 @@
+CREATE TABLE zzm_data.grafana_mapping (
+  id text not null, -- id in Grafana 3
+  uid text not null, -- uid in Grafana 6
+  PRIMARY KEY(id)
+);

--- a/database/zmon/20_api/05_stored_procedures/95_get_grafana_mapping.sql
+++ b/database/zmon/20_api/05_stored_procedures/95_get_grafana_mapping.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION get_grafana_mapping (IN p_id text) RETURNS text AS
+$BODY$
+    SELECT uid
+      FROM zzm_data.grafana_mapping
+     WHERE id = p_id
+     LIMIT 1;
+$BODY$
+LANGUAGE SQL VOLATILE SECURITY DEFINER
+COST 100;

--- a/zmon-common/src/main/java/org/zalando/zmon/persistence/GrafanaDashboardSprocService.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/persistence/GrafanaDashboardSprocService.java
@@ -68,4 +68,6 @@ public interface GrafanaDashboardSprocService {
     @SProcCall
     List<String> unstarGrafanaDashboard(@SProcParam String id, @SProcParam String user);
 
+    @SProcCall
+    String getGrafanaMapping(@SProcParam String id);
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/controller/GrafanaUIController.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/controller/GrafanaUIController.java
@@ -3,11 +3,14 @@ package org.zalando.zmon.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.zalando.zmon.api.domain.ResourceNotFoundException;
 import org.zalando.zmon.config.AppdynamicsProperties;
 import org.zalando.zmon.config.ControllerProperties;
 import org.zalando.zmon.config.EumTracingProperties;
 import org.zalando.zmon.config.KairosDBProperties;
+import org.zalando.zmon.persistence.GrafanaDashboardSprocService;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
@@ -19,6 +22,7 @@ public class GrafanaUIController {
     private AppdynamicsProperties appdynamicsProperties;
     private ControllerProperties controllerProperties;
     private EumTracingProperties eumTracingProperties;
+    private GrafanaDashboardSprocService grafanaService;
 
     public static class KairosDBEntry {
         public String name;
@@ -44,10 +48,12 @@ public class GrafanaUIController {
     public GrafanaUIController(KairosDBProperties kairosdbProperties,
                                ControllerProperties controllerProperties,
                                AppdynamicsProperties appdynamicsProperties,
-                               EumTracingProperties eumTracingProperties) {
+                               EumTracingProperties eumTracingProperties,
+                               GrafanaDashboardSprocService grafanaService) {
         this.controllerProperties = controllerProperties;
         this.appdynamicsProperties = appdynamicsProperties;
         this.eumTracingProperties = eumTracingProperties;
+        this.grafanaService = grafanaService;
 
         for (KairosDBProperties.KairosDBServiceConfig c : kairosdbProperties.getKairosdbs()) {
             kairosdbServices.add(new KairosDBEntry(c.getName(), "/rest/kairosdbs/" + c.getName()));
@@ -83,9 +89,13 @@ public class GrafanaUIController {
         return "redirect:" + request.getRequestURI().replace("/grafana2/", "/grafana/");
     }
 
-    @RequestMapping(value = "/grafana6/**")
-    public String grafana6Redirect(HttpServletRequest request) {
-        String redirect = controllerProperties.grafanaHost + request.getRequestURI().replace("/grafana6/", "");
+    @RequestMapping(value = "/grafana6/dashboard/db/{id}")
+    public String grafana6Redirect(HttpServletRequest request, @PathVariable(value = "id") String id) {
+        String uid = grafanaService.getGrafanaMapping(id);
+        if(null == uid) {
+            throw new ResourceNotFoundException();
+        }
+        String redirect = controllerProperties.grafanaHost + "/d/" + uid;
         String query = request.getQueryString();
         if(null != query) {
             redirect += "?" + query;


### PR DESCRIPTION
table is supposed to be filled by another project that moved dashboards to standalone Grafana

The reason behind needing this mapping is because ZMON recognizes Grafana dashboards by unique id (slugified from dashboard's first title), whereas Grafana 6 and higher use uid (eg. kjAm-vGZk) and slugs are fluid and change with dashboard title change. This mapping ties two unique identifiers together, so that redirection would work correctly