### PR TITLE
Prepare zmon-controller for future changes (adding runtime)

### DIFF
--- a/zmon-common/src/main/java/org/zalando/zmon/domain/CheckDefinitionImport.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/CheckDefinitionImport.java
@@ -20,7 +20,7 @@ import de.zalando.typemapper.annotations.DatabaseField;
 import de.zalando.typemapper.annotations.DatabaseType;
 
 @XmlAccessorType(XmlAccessType.NONE)
-@DatabaseType(name = "check_definition_import")
+@DatabaseType(name = "check_definition_import", partial = true)
 public class CheckDefinitionImport {
 
     @XmlElement(required = false)
@@ -100,6 +100,10 @@ public class CheckDefinitionImport {
     @DatabaseField
     @NotNull(message = "user that modified the check definition is mandatory")
     private String lastModifiedBy;
+
+    @XmlElement
+    @DatabaseField
+    private DefinitionRuntime runtime;
 
     public String getName() {
         return name;
@@ -205,6 +209,14 @@ public class CheckDefinitionImport {
         this.lastModifiedBy = lastModifiedBy;
     }
 
+    public DefinitionRuntime getRuntime() {
+        return runtime;
+    }
+
+    public void setRuntime(DefinitionRuntime runtime) {
+        this.runtime = runtime;
+    }
+
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
@@ -236,6 +248,8 @@ public class CheckDefinitionImport {
         builder.append(sourceUrl);
         builder.append(", lastModifiedBy=");
         builder.append(lastModifiedBy);
+        builder.append(", runtime=");
+        builder.append(runtime);
         builder.append("]");
         return builder.toString();
     }

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/DefinitionRuntime.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/DefinitionRuntime.java
@@ -1,0 +1,6 @@
+package org.zalando.zmon.domain;
+
+public enum DefinitionRuntime {
+    PYTHON_2,
+    PYTHON_3
+}


### PR DESCRIPTION
**Facts about java-sproc-wrapper**
[https://github.com/zalando-stups/java-sproc-wrapper](java-sproc-wrapper) is very strict when mapping database types to Java types. When there is an additional field in database type that is not present Java type it throws an exception. What is more it does the same when there is additional field in Java type but not in database type. However the latter can be suppressed by providing `partial = true` attribute to `@DatabaseType` annotation.

**Why is this needed?**
In order to provide a smooth rollout of future changes. When doing gradual deployment old version  is still there (some percentage of traffic) while new version made its db migration forward so the old version uses the new db schema for a while which would result in a crash without these changes.

This does not bring any additional, user-facing functionality.