### PR TITLE
fix env setting for alert-results

### DIFF
--- a/zmon-controller-app/src/main/java/org/zalando/zmon/api/AlertStatusAPI.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/api/AlertStatusAPI.java
@@ -55,7 +55,7 @@ public class AlertStatusAPI {
 
     private final AlertService alertService;
 
-    @Value("${zmon.rest.get-alert-results.allowed-filters")
+    @Value("${zmon.rest.get-alert-results.allowed-filters}")
     private String[] allowedFilterKeysConfig;
 
     @VisibleForTesting

--- a/zmon-controller-app/src/main/resources/config/application-github.yml
+++ b/zmon-controller-app/src/main/resources/config/application-github.yml
@@ -24,3 +24,7 @@ zmon:
           - firstTeam
           - secondTeam
           - thirdTeam
+    rest:
+      get-alert-results:
+        allowed-filters: application
+

--- a/zmon-controller-app/src/main/resources/config/application-local-test.yml
+++ b/zmon-controller-app/src/main/resources/config/application-local-test.yml
@@ -41,3 +41,7 @@ zmon:
           - firstTeam
           - secondTeam
           - thirdTeam
+    rest:
+      get-alert-results:
+        allowed-filters: application
+

--- a/zmon-controller-app/src/main/resources/config/application.yml
+++ b/zmon-controller-app/src/main/resources/config/application.yml
@@ -79,6 +79,9 @@ zmon:
           max-idle: 8
           min-idle: 0
           max-wait: -1
+    rest:
+      get-alert-results:
+        allowed-filters: application
 #
 # OAuth2: only mock tokens by default
 #


### PR DESCRIPTION
without the `}` the value is not used...