### PR TITLE
Add a runtime property to checks/alerts (frontend)

### DIFF
--- a/zmon-controller-app/src/main/java/org/zalando/zmon/config/CheckRuntimeConfig.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/config/CheckRuntimeConfig.java
@@ -8,6 +8,7 @@ import org.zalando.zmon.domain.DefinitionRuntime;
 @ConfigurationProperties(prefix = "zmon.checkruntime")
 public class CheckRuntimeConfig {
     private boolean enabled = false;
+    private String migrationGuideUrl = "";
 
     public boolean isEnabled() {
         return enabled;
@@ -15,6 +16,14 @@ public class CheckRuntimeConfig {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public String getMigrationGuideUrl() {
+        return migrationGuideUrl;
+    }
+
+    public void setMigrationGuideUrl(String migrationGuideUrl) {
+        this.migrationGuideUrl = migrationGuideUrl;
     }
 
     public DefinitionRuntime getDefaultRuntime() {

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/controller/domain/CheckRuntimeConfigDto.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/controller/domain/CheckRuntimeConfigDto.java
@@ -10,6 +10,7 @@ public class CheckRuntimeConfigDto {
     private boolean enabled;
     private DefinitionRuntime defaultRuntime;
     private Map<DefinitionRuntime, String> runtimeLabels;
+    private String migrationGuideUrl;
 
     public boolean isEnabled() {
         return enabled;
@@ -35,10 +36,19 @@ public class CheckRuntimeConfigDto {
         this.runtimeLabels = runtimeLabels;
     }
 
+    public String getMigrationGuideUrl() {
+        return migrationGuideUrl;
+    }
+
+    public void setMigrationGuideUrl(String migrationGuideUrl) {
+        this.migrationGuideUrl = migrationGuideUrl;
+    }
+
     public static CheckRuntimeConfigDto createFromCheckRuntimeConfig(CheckRuntimeConfig config) {
         CheckRuntimeConfigDto dto = new CheckRuntimeConfigDto();
         dto.setEnabled(config.isEnabled());
         dto.setDefaultRuntime(config.getDefaultRuntime());
+        dto.setMigrationGuideUrl(config.getMigrationGuideUrl());
         dto.setRuntimeLabels(DefinitionRuntime.labeledValues());
 
         return dto;

--- a/zmon-controller-app/src/main/resources/db/migration/R__function_get_check_definition_history.sql
+++ b/zmon-controller-app/src/main/resources/db/migration/R__function_get_check_definition_history.sql
@@ -24,3 +24,23 @@ LIMIT p_limit;
 $BODY$
     LANGUAGE SQL VOLATILE SECURITY DEFINER
                  COST 100;
+
+-- HACK: create same sproc with different signature to work around JDBC/SProcWrapper problem/bug
+CREATE OR REPLACE FUNCTION zzm_api.get_check_definition_history (
+    IN p_check_definition_id int,
+    IN p_limit               int,
+    IN p_from                timestamptz,
+    IN p_to                  timestamptz,
+    IN p_history_action      text
+) RETURNS SETOF zzm_api.history_entry AS
+$BODY$
+    SELECT * FROM zzm_api.get_check_definition_history(
+        p_check_definition_id,
+        p_limit,
+        p_from,
+        p_to,
+        p_history_action::zzm_data.history_action
+    );
+$BODY$
+    LANGUAGE SQL VOLATILE SECURITY DEFINER
+                 COST 100;

--- a/zmon-controller-app/src/main/resources/db/migration/R__function_get_check_definition_history.sql
+++ b/zmon-controller-app/src/main/resources/db/migration/R__function_get_check_definition_history.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION zzm_api.get_check_definition_history (
     IN p_limit               int,
     IN p_from                timestamptz,
     IN p_to                  timestamptz,
-    IN p_history_action      text
+    IN p_history_action      zzm_data.history_action
 ) RETURNS SETOF zzm_api.history_entry AS
 $BODY$
 SELECT cdh_id,

--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -312,6 +312,7 @@
 <script th:src="${staticUrl} + '/js/directives/alertHistory.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/directives/alertDowntimes.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/directives/alertDeleteModal.js?t=@buildTime@'"></script>
+<script th:src="${staticUrl} + '/js/directives/checkRuntimeSelect.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/directives/codeEditorModal.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/directives/tvLogoutModal.js?t=@buildTime@'"></script>
 <script th:src="${staticUrl} + '/js/directives/consentModal.js?t=@buildTime@'"></script>

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/checkruntime/CheckRuntimeDisabledIT.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/checkruntime/CheckRuntimeDisabledIT.java
@@ -50,7 +50,7 @@ public class CheckRuntimeDisabledIT extends BaseCheckRuntimeIT {
 
         assertThat(checkRuntimeConfig.isEnabled(), is(false));
         assertThat(checkRuntimeConfig.getDefaultRuntime(), is(DefinitionRuntime.PYTHON_2));
-        assertThat(checkRuntimeConfig.getMigrationGuideUrl(), is("#"));
+        assertThat(checkRuntimeConfig.getMigrationGuideUrl(), is(""));
     }
 
     @Test

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/checkruntime/CheckRuntimeDisabledIT.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/checkruntime/CheckRuntimeDisabledIT.java
@@ -50,6 +50,7 @@ public class CheckRuntimeDisabledIT extends BaseCheckRuntimeIT {
 
         assertThat(checkRuntimeConfig.isEnabled(), is(false));
         assertThat(checkRuntimeConfig.getDefaultRuntime(), is(DefinitionRuntime.PYTHON_2));
+        assertThat(checkRuntimeConfig.getMigrationGuideUrl(), is("#"));
     }
 
     @Test

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/checkruntime/CheckRuntimeEnabledIT.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/checkruntime/CheckRuntimeEnabledIT.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.is;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-        properties = {"server.ssl.enabled=false", "zmon.checkruntime.enabled=true", "zmon.checkruntime.migrationguideurl=http://example.com"}
+        properties = {"server.ssl.enabled=false", "zmon.checkruntime.enabled=true", "zmon.checkruntime.migrationGuideUrl=http://example.com"}
 )
 @Transactional
 public class CheckRuntimeEnabledIT extends BaseCheckRuntimeIT {

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/checkruntime/CheckRuntimeEnabledIT.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/checkruntime/CheckRuntimeEnabledIT.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.is;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-        properties = {"server.ssl.enabled=false", "zmon.checkruntime.enabled=true"}
+        properties = {"server.ssl.enabled=false", "zmon.checkruntime.enabled=true", "zmon.checkruntime.migrationguideurl=http://example.com"}
 )
 @Transactional
 public class CheckRuntimeEnabledIT extends BaseCheckRuntimeIT {
@@ -42,6 +42,7 @@ public class CheckRuntimeEnabledIT extends BaseCheckRuntimeIT {
 
         assertThat(checkRuntimeConfig.isEnabled(), is(true));
         assertThat(checkRuntimeConfig.getDefaultRuntime(), is(DefinitionRuntime.PYTHON_3));
+        assertThat(checkRuntimeConfig.getMigrationGuideUrl(), is("http://example.com"));
     }
 
     @Test

--- a/zmon-controller-ui/js/controllers/TrialRunCtrl.js
+++ b/zmon-controller-ui/js/controllers/TrialRunCtrl.js
@@ -198,10 +198,10 @@ var TrialRunCtrl = function ($scope, $interval, $timeout, timespanFilter, Commun
     };
 
     $scope.alert = _.extend($scope.alert || {}, {
-       entities: [],
-       entities_exclude: [],
-       parameters: [],
-       interval: 120
+        entities: [],
+        entities_exclude: [],
+        parameters: [],
+        interval: 120
     });
 
     // Deep watch
@@ -295,31 +295,28 @@ var TrialRunCtrl = function ($scope, $interval, $timeout, timespanFilter, Commun
     var urlJson =JSON.parse($location.search().json)
     }
 
-     if($routeParams.checkId){
-        $scope.checkId = $routeParams.checkId
-            CommunicationService.getCheckDefinition($scope.checkId).then(
-                function(response) {
-                    $scope.alert = response;
-                    $scope.alert.check_command = $scope.alert.command;
+    if ($routeParams.checkId) {
+        $scope.checkId = $routeParams.checkId;
+        CommunicationService.getCheckDefinition($scope.checkId).then(
+            function (response) {
+                $scope.alert = response;
+                $scope.alert.check_command = $scope.alert.command;
 
-                    if (urlJson) {
-                        _.extend($scope.alert, urlJson);
-                    }
-                    if ($scope.alert.owning_team && trc.teams.indexOf($scope.alert.owning_team) === -1) {
-                        trc.teams.push($scope.alert.owning_team);
-                    }
-                    trc.entityFilter.formEntityFilters = $scope.alert.entities;
-                    trc.entityFilter.textEntityFilters = JSON.stringify($scope.alert.entities, null, trc.INDENT);
-                    trc.entityExcludeFilter.formEntityFilters = $scope.alert.entities_exclude ? $scope.alert.entities_exclude:[];
-                    trc.entityExcludeFilter.textEntityFilters = $scope.alert.entities_exclude ? JSON.stringify($scope.alert.entities_exclude, null, trc.INDENT):"[]";
-                    trc.parameters = formParametersArray($scope.alert.parameters);
-                
+                if (urlJson) {
+                    _.extend($scope.alert, urlJson);
+                }
+                if ($scope.alert.owning_team && trc.teams.indexOf($scope.alert.owning_team) === -1) {
+                    trc.teams.push($scope.alert.owning_team);
+                }
+                trc.entityFilter.formEntityFilters = $scope.alert.entities;
+                trc.entityFilter.textEntityFilters = JSON.stringify($scope.alert.entities, null, trc.INDENT);
+                trc.entityExcludeFilter.formEntityFilters = $scope.alert.entities_exclude ? $scope.alert.entities_exclude : [];
+                trc.entityExcludeFilter.textEntityFilters = $scope.alert.entities_exclude ? JSON.stringify($scope.alert.entities_exclude, null, trc.INDENT) : "[]";
+                trc.parameters = formParametersArray($scope.alert.parameters);
+            }
+        );
 
-                   
-                    }
-            );
-        
-    }else if (urlJson) {
+    } else if (urlJson) {
         _.extend($scope.alert, urlJson);
     }
     
@@ -368,6 +365,7 @@ var TrialRunCtrl = function ($scope, $interval, $timeout, timespanFilter, Commun
             obj.name = $scope.alert.name.trim();
             obj.entities = $scope.alert.entities;
             obj.command = $scope.alert.check_command;
+            obj.runtime = $scope.alert.runtime;
             obj.interval = $scope.alert.interval;
             obj.description = $scope.alert.description;
             obj.owning_team = $scope.alert.owning_team.trim();
@@ -509,7 +507,8 @@ var TrialRunCtrl = function ($scope, $interval, $timeout, timespanFilter, Commun
             name: $scope.alert.name,
             description: $scope.alert.description || "TrialRun Test",
             status: 'ACTIVE',
-            interval: $scope.alert.interval
+            interval: $scope.alert.interval,
+            runtime: $scope.alert.runtime
         };
 
         if (typeof $scope.alert.entities !== 'undefined' && $scope.alert.entities.length) {

--- a/zmon-controller-ui/js/directives/checkRuntimeSelect.js
+++ b/zmon-controller-ui/js/directives/checkRuntimeSelect.js
@@ -1,0 +1,73 @@
+angular.module('zmon2App').directive('checkRuntimeSelect', ['$q', 'CommunicationService', function($q, CommunicationService) {
+    return {
+        restrict: 'E',
+        templateUrl: 'templates/checkRuntimeSelect.html',
+        scope: {
+            name: '@',
+            readOnly: '@',
+            checkId: '=',
+            runtime: '='
+        },
+        link: function (scope, elem, attrs) {
+            // Set static defaults
+            scope.name = scope.name || 'runtime';
+            scope.readOnly = scope.readOnly || false;
+            scope.warn = false;
+
+            var generateContextFromConfig = function(configResource) {
+                return {
+                    enabled: configResource.enabled,
+                    allRuntimes: configResource.runtime_labels,
+                    defaultRuntime: configResource.default_runtime
+                };
+            };
+
+            var disableDirectiveOrContinue = function(context) {
+                scope.enabled = context.enabled;
+                if (!scope.enabled) return $q.reject();
+
+                return context;
+            };
+
+            var setInitialRuntime = function(context) {
+                if (!scope.checkId) {
+                    context.initialRuntime = context.defaultRuntime;
+                    scope.runtime = _.clone(context.defaultRuntime);
+
+                    return context;
+                }
+
+                return CommunicationService.getAllChanges({check_definition_id: scope.checkId, action: 'INSERT'})
+                    .then(function(changesResources) {
+                        context.initialRuntime = _.clone(changesResources[0].attributes.cd_runtime);
+
+                        return context;
+                    });
+            };
+
+            var setChoices = function(context) {
+                if (context.initialRuntime === context.defaultRuntime) {
+                    scope.choices = _.pick(context.allRuntimes, context.defaultRuntime);
+                }
+                else {
+                    scope.choices = context.allRuntimes;
+                }
+
+                return context;
+            };
+
+            var setupRuntimeWatch = function(context) {
+                scope.$watch('runtime', function(newValue) {
+                    scope.warn = !scope.readOnly && (newValue !== context.defaultRuntime);
+                });
+            };
+
+            CommunicationService.getCheckRuntimeConfig()
+                .then(generateContextFromConfig)
+                .then(disableDirectiveOrContinue)
+                .then(setInitialRuntime)
+                .then(setChoices)
+                .then(setupRuntimeWatch);
+        }
+    }
+}]);

--- a/zmon-controller-ui/js/directives/checkRuntimeSelect.js
+++ b/zmon-controller-ui/js/directives/checkRuntimeSelect.js
@@ -46,8 +46,8 @@ angular.module('zmon2App').directive('checkRuntimeSelect', ['$q', 'Communication
             };
 
             var setChoices = function(context) {
-                if (context.initialRuntime === context.defaultRuntime) {
-                    scope.choices = _.pick(context.allRuntimes, context.defaultRuntime);
+                if (context.initialRuntime === 'PYTHON_3') {
+                    scope.choices = _.pick(context.allRuntimes, 'PYTHON_3');
                 }
                 else {
                     scope.choices = context.allRuntimes;

--- a/zmon-controller-ui/js/services/CommunicationService.js
+++ b/zmon-controller-ui/js/services/CommunicationService.js
@@ -728,6 +728,10 @@ angular.module('zmon2App').factory('CommunicationService', ['$http', '$q', '$log
             return doHttpCall("GET", "/rest/user/subscriptions");
         };
 
+        service.getCheckRuntimeConfig = function() {
+            return doHttpCall("GET", "/rest/checkRuntimeConfig");
+        };
+
         return service;
     }
 ]);

--- a/zmon-controller-ui/templates/checkRuntimeSelect.html
+++ b/zmon-controller-ui/templates/checkRuntimeSelect.html
@@ -15,7 +15,7 @@
             <p ng-show="warn">
                 <strong>
                     This check uses Python 2 that is deprecated and will be soon discontinued.<br>
-                    Please follow <a href="#">the migration guide</a> in order to migrate it to Python 3.
+                    Please follow <a href="{{ migrationGuideUrl }}">the migration guide</a> in order to migrate it to Python 3.
                 </strong>
             </p>
             <p ng-switch-when="false">Python version that the check command and its alert conditions will be evaluated

--- a/zmon-controller-ui/templates/checkRuntimeSelect.html
+++ b/zmon-controller-ui/templates/checkRuntimeSelect.html
@@ -1,0 +1,27 @@
+<div class="form-group" ng-show="enabled" ng-class="{'has-warning': warn}">
+    <label for="runtime" class="col-sm-2 control-label">Runtime</label>
+    <div class="col-sm-10">
+        <select name="{{ name }}"
+                id="runtime"
+                class="form-control"
+                ng-disabled="readOnly"
+                ng-model="runtime">
+            <option ng-repeat="(value, label) in choices"
+                    value="{{ value }}">
+                {{ label }}
+            </option>
+        </select>
+        <div class="help-block" ng-switch="readOnly">
+            <p ng-show="warn">
+                <strong>
+                    This check uses Python 2 that is deprecated and will be soon discontinued.<br>
+                    Please follow <a href="#">the migration guide</a> in order to migrate it to Python 3.
+                </strong>
+            </p>
+            <p ng-switch-when="false">Python version that the check command and its alert conditions will be evaluated
+                with.</p>
+            <p ng-switch-when="true">Python version that the alert condition will be evaluated with. This value is
+                determined by the related check and cannot be adjusted per alert.</p>
+        </div>
+    </div>
+</div>

--- a/zmon-controller-ui/views/alertDefinitionEditForm.html
+++ b/zmon-controller-ui/views/alertDefinitionEditForm.html
@@ -102,6 +102,8 @@
         </div>
     </div>
 
+    <check-runtime-select runtime="checkDefinition.runtime" check-id="checkDefinitionId" read-only="true"></check-runtime-select>
+
     <div class="form-group" ng-class="{'has-error': adForm.submitted && adForm.parameters.$error['valid-json'] || adForm.parameters.$error.required }">
         <label for="inp-parameters" class="col-sm-2 control-label">
             <div>

--- a/zmon-controller-ui/views/checkDefinitionEditForm.html
+++ b/zmon-controller-ui/views/checkDefinitionEditForm.html
@@ -51,6 +51,8 @@
         </div>
     </div>
 
+    <check-runtime-select runtime="check.runtime" check-id="checkId"></check-runtime-select>
+
     <div class="form-group" ng-class="{'has-error': cdForm.submitted && cdForm.entities.$error['valid-json'] || cdForm.entities.$error.required }">
         <label for="inp-entities" class="col-sm-2 control-label">
             <a href="https://docs.zmon.io/en/latest/user/check-definitions.html#entity-filter" rel="help" target="docs">Included Entities</a>

--- a/zmon-controller-ui/views/trialRun.html
+++ b/zmon-controller-ui/views/trialRun.html
@@ -67,13 +67,15 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="inp-condition" class="col-sm-2 control-label"><a href="https://docs.zmon.io/en/latest/user/alert-definitions.html#condition" rel="help" target="docs">Alert Condition</a></label>
+                        <label for="inp-condition" class="col-sm-2 control-label"><a href="https://docs.zmon.io/en/latest/user/alert-definitions.html#condition" rel="help" target="docs">Alert Condition *</a></label>
                         <div class="col-sm-10">
                             <code-editor-modal code="alert.alert_condition" title="Alert Condition" language="python"></code-editor-modal>
                             <div id="inp-condition" name="alert_condition" class="code-editor" ng-model="alert.alert_condition" code-language="python" code-editor></div>
                             <span class="help-block">Valid Python expression to return true when alert should be "on". Use <code>value</code> to access the check result value.</span>
                         </div>
                     </div>
+
+                    <check-runtime-select runtime="alert.runtime" check-id="checkId"></check-runtime-select>
 
                     <div class="form-group" ng-class="{'has-error': trForm.submitted && trForm.parameters.$error['valid-json'] || trForm.parameters.$error.required }">
                         <label for="inp-parameters" class="col-sm-2 control-label">


### PR DESCRIPTION
Part of a preparation for zmon-worker Python 3 migration.

Scope:
- add a directive that shows selection of runtime based on feature toggle configuration and initial runtime,
- add a config property to parametrize migration guide URL later,
- fix get history stored procedure for correct type (it's currently broken)

Depends on https://github.com/zalando-zmon/zmon-controller/pull/727