### PR TITLE
query params for querying AlertIDs for listFalsePositiveRates

### DIFF
--- a/zmon-controller-app/src/main/java/org/zalando/zmon/api/FalsePositiveRateApi.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/api/FalsePositiveRateApi.java
@@ -42,7 +42,7 @@ public class FalsePositiveRateApi {
     }
 
     @ResponseBody
-    @GetMapping(value = "/")
+    @GetMapping(value = "")
     public ResponseEntity<JsonNode> listFalsePositiveRates(@RequestParam(name = "id", required = true) String[] idList) {
         return falsePositiveRateService.listFalsePositiveRates(idList);
     }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/api/FalsePositiveRateApi.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/api/FalsePositiveRateApi.java
@@ -43,7 +43,7 @@ public class FalsePositiveRateApi {
 
     @ResponseBody
     @GetMapping(value = "/")
-    public ResponseEntity<JsonNode> listFalsePositiveRates(@RequestBody(required = true) String ids) {
-        return falsePositiveRateService.listFalsePositiveRates(ids);
+    public ResponseEntity<JsonNode> listFalsePositiveRates(@RequestParam(name = "id", required = true) String[] idList) {
+        return falsePositiveRateService.listFalsePositiveRates(idList);
     }
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/controller/FalsePositiveRateController.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/controller/FalsePositiveRateController.java
@@ -1,8 +1,6 @@
-package org.zalando.zmon.api;
+package org.zalando.zmon.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -14,16 +12,13 @@ import java.util.Map;
 /**
  * @author raparida
  */
-
 @Controller
-@RequestMapping(value = "/api/v1/false-positive-rates")
-public class FalsePositiveRateApi {
-
+@RequestMapping(value = "/rest/false-positive-rates")
+public class FalsePositiveRateController {
     private final FalsePositiveRateService falsePositiveRateService;
-    private final Logger log = LoggerFactory.getLogger(FalsePositiveRateApi.class);
 
     @Autowired
-    public FalsePositiveRateApi(FalsePositiveRateService falsePositiveRateService) {
+    public FalsePositiveRateController(FalsePositiveRateService falsePositiveRateService) {
         this.falsePositiveRateService = falsePositiveRateService;
     }
 
@@ -43,7 +38,7 @@ public class FalsePositiveRateApi {
 
     @ResponseBody
     @GetMapping(value = "")
-    public ResponseEntity<JsonNode> listFalsePositiveRates(@RequestParam(name = "id", required = true) String[] idList) {
+    public ResponseEntity<JsonNode> listFalsePositiveRates(@RequestParam(name = "id") String[] idList) {
         return falsePositiveRateService.listFalsePositiveRates(idList);
     }
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/FalsePositiveRateService.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/FalsePositiveRateService.java
@@ -14,5 +14,5 @@ public interface FalsePositiveRateService {
 
     ResponseEntity<JsonNode> getFalsePositiveRateDataPoints(String id, Map<String, String> query);
 
-    ResponseEntity<JsonNode> listFalsePositiveRates(String ids);
+    ResponseEntity<JsonNode> listFalsePositiveRates(String[] idList);
 }

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/FalsePositiveRateServiceImpl.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/FalsePositiveRateServiceImpl.java
@@ -102,18 +102,19 @@ public class FalsePositiveRateServiceImpl implements FalsePositiveRateService {
     }
 
     @Override
-    public ResponseEntity<JsonNode> listFalsePositiveRates(final String alertIdList) {
+    public ResponseEntity<JsonNode> listFalsePositiveRates(final String[] idList) {
         log.debug("Bulk get false positive rates");
         final String url = metaDataProperties.getUrl() + FALSE_POSITIVE_RATE_END_POINT;
-
         try {
-            Request request = Request.Post(url);
+            UriComponentsBuilder urlBuilder = UriComponentsBuilder.fromUriString(url)
+                    .queryParam("id", idList);
             log.debug("URL: {}", url);
 
+            Request request = Request.Get(urlBuilder.build().toUri());
+
             request.addHeader(AUTHORIZATION, BEARER + accessTokens.get(ZMON_TOKEN_ID));
-            HttpResponse response = executor.execute(request.bodyString(
-                    alertIdList, ContentType.APPLICATION_JSON))
-                    .returnResponse();
+            HttpResponse response = executor.execute(request).returnResponse();
+
             return toResponseEntity(response);
         } catch (Exception ex) {
             log.error("Bulk get of false positive rate failed", ex);


### PR DESCRIPTION
Use query params for getting AlertID list for listFalsePositiveRates instead of the request body

Signed-off-by: Rajat parida <rajat.parida@zalando.de>