### PR TITLE
add missing dependency argument to TrialRunCtrl.js

### DIFF
--- a/zmon-controller-ui/js/controllers/TrialRunCtrl.js
+++ b/zmon-controller-ui/js/controllers/TrialRunCtrl.js
@@ -1,4 +1,5 @@
-var TrialRunCtrl = function ($scope, $interval, $timeout, timespanFilter, CommunicationService, MainAlertService, FeedbackMessageService, UserInfoService, $window, $location, $routeParams, BootConfig) {
+angular.module('zmon2App').controller('TrialRunCtrl', ['$scope', '$interval', '$timeout', 'timespanFilter', 'CommunicationService', 'MainAlertService', 'FeedbackMessageService', 'UserInfoService', '$window', '$location', '$routeParams', 'BootConfig',
+  function ($scope, $interval, $timeout, timespanFilter, CommunicationService, MainAlertService, FeedbackMessageService, UserInfoService, $window, $location, $routeParams, BootConfig) {
 
     $scope.$parent.activePage = 'trial-run';
     MainAlertService.removeDataRefresh();
@@ -585,7 +586,4 @@ var TrialRunCtrl = function ($scope, $interval, $timeout, timespanFilter, Commun
         }
         return options.sort();
     };
-};
-
-
-angular.module('zmon2App').controller('TrialRunCtrl', ['$scope', '$interval', '$timeout', 'timespanFilter', 'CommunicationService', 'MainAlertService', 'FeedbackMessageService', 'UserInfoService', '$window', '$location', '$routeParams', TrialRunCtrl]);
+}]);


### PR DESCRIPTION
dependencies for TrialRunCtrl were specified at the bottom of the file, whereas function definition was at the top. This moves them together to the top and adds missing dependency - `BootConfig`