### PR TITLE
adds service level config status to /status endpoint response

### DIFF
--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ExecutionStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ExecutionStatus.java
@@ -17,12 +17,14 @@ public class ExecutionStatus {
     private final int queueSize;
     private final Set<Worker> workers;
     private final Set<Queue> queues;
+    private final ServiceLevelStatus.ServiceLevelStatusData serviceLevelStatus;
 
     private ExecutionStatus(final Builder builder) {
         this.alertsActive = builder.alertsActive;
         this.workersActive = builder.workersActive;
         this.workers = builder.workers.build();
         this.queues = builder.queues.build();
+        this.serviceLevelStatus = builder.serviceLevelStatus;
         this.workersTotal = this.workers.size();
         this.checkInvocations = checkInvocations(this.workers);
         this.queueSize = totalQueueSize(this.queues);
@@ -48,6 +50,10 @@ public class ExecutionStatus {
         return queueSize;
     }
 
+    public ServiceLevelStatus.ServiceLevelStatusData getServiceLevelStatus() {
+        return serviceLevelStatus;
+    }
+
     public Set<Worker> getWorkers() {
         return workers;
     }
@@ -65,6 +71,7 @@ public class ExecutionStatus {
         sb.append(", queueSize=").append(queueSize);
         sb.append(", workers=").append(workers);
         sb.append(", queues=").append(queues);
+        sb.append(", serviceLevelStatus=").append(serviceLevelStatus);
         sb.append('}');
         return sb.toString();
     }
@@ -96,6 +103,7 @@ public class ExecutionStatus {
         // optional
         private int alertsActive = 0;
         private int workersActive = 0;
+        private ServiceLevelStatus.ServiceLevelStatusData serviceLevelStatus = new ServiceLevelStatus.ServiceLevelStatusData();
         private final ImmutableSet.Builder<Worker> workers = ImmutableSet.builder();
         private final ImmutableSet.Builder<Queue> queues = ImmutableSet.builder();
 
@@ -111,6 +119,13 @@ public class ExecutionStatus {
         public Builder withWorkersActive(final int workersActive) {
             Preconditions.checkNotNull(workersActive >= 0);
             this.workersActive = workersActive;
+
+            return this;
+        }
+
+        public Builder withServiceLevelStatus(final ServiceLevelStatus.ServiceLevelStatusData status) {
+            Preconditions.checkNotNull(status);
+            this.serviceLevelStatus = status;
 
             return this;
         }

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ExecutionStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ExecutionStatus.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import org.zalando.zmon.domain.ServiceLevelStatus.ServiceLevelStatusData;
 
 /**
  * Created by pribeiro on 17/07/14.
@@ -17,7 +18,7 @@ public class ExecutionStatus {
     private final int queueSize;
     private final Set<Worker> workers;
     private final Set<Queue> queues;
-    private final ServiceLevelStatus.ServiceLevelStatusData serviceLevelStatus;
+    private final ServiceLevelStatusData serviceLevelStatus;
 
     private ExecutionStatus(final Builder builder) {
         this.alertsActive = builder.alertsActive;
@@ -50,7 +51,7 @@ public class ExecutionStatus {
         return queueSize;
     }
 
-    public ServiceLevelStatus.ServiceLevelStatusData getServiceLevelStatus() {
+    public ServiceLevelStatusData getServiceLevelStatus() {
         return serviceLevelStatus;
     }
 
@@ -103,7 +104,7 @@ public class ExecutionStatus {
         // optional
         private int alertsActive = 0;
         private int workersActive = 0;
-        private ServiceLevelStatus.ServiceLevelStatusData serviceLevelStatus = new ServiceLevelStatus.ServiceLevelStatusData();
+        private ServiceLevelStatusData serviceLevelStatus = new ServiceLevelStatusData();
         private final ImmutableSet.Builder<Worker> workers = ImmutableSet.builder();
         private final ImmutableSet.Builder<Queue> queues = ImmutableSet.builder();
 
@@ -123,7 +124,7 @@ public class ExecutionStatus {
             return this;
         }
 
-        public Builder withServiceLevelStatus(final ServiceLevelStatus.ServiceLevelStatusData status) {
+        public Builder withServiceLevelStatus(final ServiceLevelStatusData status) {
             Preconditions.checkNotNull(status);
             this.serviceLevelStatus = status;
 

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
@@ -1,11 +1,16 @@
 package org.zalando.zmon.domain;
 
+import java.util.HashMap;
+
 public class ServiceLevelStatus {
     private ServiceLevelStatusData data;
     private String lastModified;
     private String lastModifiedBy;
 
     public ServiceLevelStatusData getData() {
+        if (data == null) {
+            return new ServiceLevelStatusData();
+        }
         return data;
     }
 
@@ -34,6 +39,46 @@ public class ServiceLevelStatus {
         private Integer ingestMaxCheckTier = 3;
         private Integer queryDistanceHoursLimit = 0;
         private Integer queryMaxCheckTier = 3;
+        private final HashMap<Integer, String> checkTiers;
+
+        public ServiceLevelStatusData() {
+            this.checkTiers = new HashMap<>();
+            this.checkTiers.put(2, "metrics classified as \"important\" and \"critical\"");
+            this.checkTiers.put(1, "metrics classified as \"critical\"");
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage() {
+            this.message = "";
+
+            if (this.ingestMaxCheckTier != 3 && this.queryMaxCheckTier != 3) {
+                this.message = "Metric visualization is currently only available for " + this.checkTiers.get(this.queryMaxCheckTier) + ", " +
+                        "metric storage only for " +  this.checkTiers.get(this.ingestMaxCheckTier);
+            }
+
+            if (this.ingestMaxCheckTier != 3 && this.queryMaxCheckTier == 3) {
+                this.message = "Metric visualization is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";
+            }
+
+            if (this.ingestMaxCheckTier == 3 && this.queryMaxCheckTier != 3) {
+                this.message = "Metric storage is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";
+            }
+
+            if (this.queryDistanceHoursLimit != 0) {
+                if (this.ingestMaxCheckTier != 3 || this.queryMaxCheckTier != 3) {
+                    this.message += " and ";
+                } else {
+                  this.message = "Metric visualization ";
+                }
+                this.message += "is temporarily limited to a " + this.queryDistanceHoursLimit + " hour span.";
+            }
+
+        }
+
+        private String message;
 
         public Integer getIngestMaxCheckTier() {
             return ingestMaxCheckTier;
@@ -59,12 +104,14 @@ public class ServiceLevelStatus {
             this.queryMaxCheckTier = queryMaxCheckTier;
         }
 
+
         @Override
         public String toString() {
             final StringBuilder sb = new StringBuilder("ServiceLevelStatus{");
             sb.append("ingestMaxCheckTier=").append(ingestMaxCheckTier);
             sb.append(", queryDistanceHoursLimit=").append(queryDistanceHoursLimit);
             sb.append(", queryMaxCheckTier=").append(queryMaxCheckTier);
+            sb.append(", message=").append(message);
             sb.append('}');
             return sb.toString();
         }

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
@@ -1,0 +1,73 @@
+package org.zalando.zmon.domain;
+
+public class ServiceLevelStatus {
+    private ServiceLevelStatusData data;
+    private String lastModified;
+    private String lastModifiedBy;
+
+    public ServiceLevelStatusData getData() {
+        return data;
+    }
+
+    public void setData(ServiceLevelStatusData data) {
+        this.data = data;
+    }
+
+    public String getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(String lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    public String getLastModifiedBy() {
+        return lastModifiedBy;
+    }
+
+    public void setLastModifiedBy(String lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
+    }
+
+
+    public static class ServiceLevelStatusData {
+        private Integer ingestMaxCheckTier = 0;
+        private Integer queryDistanceHoursLimit = 0;
+        private Integer queryMaxCheckTier = 0;
+
+        public Integer getIngestMaxCheckTier() {
+            return ingestMaxCheckTier;
+        }
+
+        public void setIngestMaxCheckTier(Integer ingestMaxCheckTier) {
+            this.ingestMaxCheckTier = ingestMaxCheckTier;
+        }
+
+        public Integer getQueryDistanceHoursLimit() {
+            return queryDistanceHoursLimit;
+        }
+
+        public void setQueryDistanceHoursLimit(Integer queryDistanceHoursLimit) {
+            this.queryDistanceHoursLimit = queryDistanceHoursLimit;
+        }
+
+        public Integer getQueryMaxCheckTier() {
+            return queryMaxCheckTier;
+        }
+
+        public void setQueryMaxCheckTier(Integer queryMaxCheckTier) {
+            this.queryMaxCheckTier = queryMaxCheckTier;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("ServiceLevelStatus{");
+            sb.append("ingestMaxCheckTier=").append(ingestMaxCheckTier);
+            sb.append(", queryDistanceHoursLimit=").append(queryDistanceHoursLimit);
+            sb.append(", queryMaxCheckTier=").append(queryMaxCheckTier);
+            sb.append('}');
+            return sb.toString();
+        }
+    }
+}
+

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
@@ -53,7 +53,11 @@ public class ServiceLevelStatus {
         }
 
         public void setMessage() {
-            this.message = "SERVICE DEGRADATION: ";
+            this.message = "";
+
+            if (this.queryMaxCheckTier != 3 || this.ingestMaxCheckTier != 3 || this.queryDistanceHoursLimit != 0) {
+                this.message = "SERVICE DEGRADATION: ";
+            }
 
             if (this.queryMaxCheckTier != 3) {
                 this.message += "Metric visualization is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
@@ -31,9 +31,9 @@ public class ServiceLevelStatus {
 
 
     public static class ServiceLevelStatusData {
-        private Integer ingestMaxCheckTier = 0;
+        private Integer ingestMaxCheckTier = 3;
         private Integer queryDistanceHoursLimit = 0;
-        private Integer queryMaxCheckTier = 0;
+        private Integer queryMaxCheckTier = 3;
 
         public Integer getIngestMaxCheckTier() {
             return ingestMaxCheckTier;

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
@@ -63,17 +63,15 @@ public class ServiceLevelStatus {
                 this.message = "Metric visualization is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";
             }
 
-            if (this.ingestMaxCheckTier == 3 && this.queryMaxCheckTier != 3) {
-                this.message = "Metric storage is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";
-            }
-
             if (this.queryDistanceHoursLimit != 0) {
-                if (this.ingestMaxCheckTier != 3 || this.queryMaxCheckTier != 3) {
+                if (this.queryMaxCheckTier != 3) {
                     this.message += " and ";
-                } else {
-                  this.message = "Metric visualization ";
                 }
                 this.message += "is temporarily limited to a " + this.queryDistanceHoursLimit + " hour span.";
+            }
+
+            if (this.ingestMaxCheckTier == 3 && this.queryMaxCheckTier != 3) {
+                this.message = "Metric storage is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";
             }
 
         }

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
@@ -52,17 +52,17 @@ public class ServiceLevelStatus {
         }
 
         public void setMessage() {
-            this.message = "";
+            this.message = "SERVICE DEGRADATION: ";
 
             if (this.queryMaxCheckTier != 3) {
-                this.message = "Metric visualization is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";
+                this.message += "Metric visualization is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";
             }
 
             if (this.queryDistanceHoursLimit != 0) {
                 if (this.queryMaxCheckTier != 3) {
                     this.message += " and ";
                 } else {
-                    this.message = "Metric visualization ";
+                    this.message += "Metric visualization ";
                 }
                 this.message += "is temporarily limited to a " + this.queryDistanceHoursLimit + " hour span.";
             }

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
@@ -40,6 +40,7 @@ public class ServiceLevelStatus {
         private Integer queryDistanceHoursLimit = 0;
         private Integer queryMaxCheckTier = 3;
         private final HashMap<Integer, String> checkTiers;
+        private String message;
 
         public ServiceLevelStatusData() {
             this.checkTiers = new HashMap<>();
@@ -70,10 +71,7 @@ public class ServiceLevelStatus {
             if (this.ingestMaxCheckTier != 3) {
                 this.message += " Metric storage is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + ".";
             }
-
         }
-
-        private String message;
 
         public Integer getIngestMaxCheckTier() {
             return ingestMaxCheckTier;

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
@@ -54,24 +54,21 @@ public class ServiceLevelStatus {
         public void setMessage() {
             this.message = "";
 
-            if (this.ingestMaxCheckTier != 3 && this.queryMaxCheckTier != 3) {
-                this.message = "Metric visualization is currently only available for " + this.checkTiers.get(this.queryMaxCheckTier) + ", " +
-                        "metric storage only for " +  this.checkTiers.get(this.ingestMaxCheckTier);
-            }
-
-            if (this.ingestMaxCheckTier != 3 && this.queryMaxCheckTier == 3) {
+            if (this.queryMaxCheckTier != 3) {
                 this.message = "Metric visualization is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";
             }
 
             if (this.queryDistanceHoursLimit != 0) {
                 if (this.queryMaxCheckTier != 3) {
                     this.message += " and ";
+                } else {
+                    this.message = "Metric visualization ";
                 }
                 this.message += "is temporarily limited to a " + this.queryDistanceHoursLimit + " hour span.";
             }
 
-            if (this.ingestMaxCheckTier == 3 && this.queryMaxCheckTier != 3) {
-                this.message = "Metric storage is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + " ";
+            if (this.ingestMaxCheckTier != 3) {
+                this.message += " Metric storage is currently only available for " + this.checkTiers.get(this.ingestMaxCheckTier) + ".";
             }
 
         }

--- a/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
+++ b/zmon-common/src/main/java/org/zalando/zmon/domain/ServiceLevelStatus.java
@@ -52,7 +52,7 @@ public class ServiceLevelStatus {
             return message;
         }
 
-        public void setMessage() {
+        public void fillMessage() {
             this.message = "";
 
             if (this.queryMaxCheckTier != 3 || this.ingestMaxCheckTier != 3 || this.queryDistanceHoursLimit != 0) {

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/ZMonServiceImpl.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/ZMonServiceImpl.java
@@ -646,6 +646,7 @@ public class ZMonServiceImpl implements ZMonService {
         if (entities.size() == 1) {
             try {
                 final ServiceLevelStatus.ServiceLevelStatusData status = mapper.readValue(entities.get(0), ServiceLevelStatus.class).getData();
+                status.setMessage();
                 builder.withServiceLevelStatus(status);
             } catch (IOException e) {
                 log.error("Cannot read zmon-service-level-config entity,", e);

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/ZMonServiceImpl.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/ZMonServiceImpl.java
@@ -646,7 +646,7 @@ public class ZMonServiceImpl implements ZMonService {
         if (entities.size() == 1) {
             try {
                 final ServiceLevelStatus.ServiceLevelStatusData status = mapper.readValue(entities.get(0), ServiceLevelStatus.class).getData();
-                status.setMessage();
+                status.fillMessage();
                 builder.withServiceLevelStatus(status);
             } catch (IOException e) {
                 log.error("Cannot read zmon-service-level-config entity,", e);

--- a/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/ZMonServiceImpl.java
+++ b/zmon-controller-app/src/main/java/org/zalando/zmon/service/impl/ZMonServiceImpl.java
@@ -33,6 +33,7 @@ import org.zalando.zmon.config.SchedulerProperties;
 import org.zalando.zmon.diff.CheckDefinitionsDiffFactory;
 import org.zalando.zmon.domain.*;
 import org.zalando.zmon.domain.CheckDefinition.Criticality;
+import org.zalando.zmon.domain.ServiceLevelStatus.ServiceLevelStatusData;
 import org.zalando.zmon.event.ZMonEventType;
 import org.zalando.zmon.exception.SerializationException;
 import org.zalando.zmon.persistence.*;
@@ -645,7 +646,7 @@ public class ZMonServiceImpl implements ZMonService {
 
         if (entities.size() == 1) {
             try {
-                final ServiceLevelStatus.ServiceLevelStatusData status = mapper.readValue(entities.get(0), ServiceLevelStatus.class).getData();
+                final ServiceLevelStatusData status = mapper.readValue(entities.get(0), ServiceLevelStatus.class).getData();
                 status.fillMessage();
                 builder.withServiceLevelStatus(status);
             } catch (IOException e) {

--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -143,7 +143,7 @@
     </script>
 
     <script th:inline="javascript">
-        var zmonBootData = /*[[${zmonBootData}]]*/ {};
+        var zmonBootData = {};
     </script>
 
     <link rel="manifest" href="/manifest.json">
@@ -263,6 +263,13 @@
     <div class="main-wrapper" ng-class="{'globalSearchVisible':globalSearchVisible}">
         <div id="message-manager-wrapper">
             <span class="message"></span>
+        </div>
+        <div ng-if="serviceStatus.serviceLevelStatusMessage"
+             class="service-level-warning">
+            <div>
+                <span class="fa fa-warning"></span>
+                {{serviceStatus.serviceLevelStatusMessage}}
+            </div>
         </div>
         <div id="main" ng-view></div>
     </div>

--- a/zmon-controller-app/src/main/resources/templates/index.html
+++ b/zmon-controller-app/src/main/resources/templates/index.html
@@ -143,7 +143,7 @@
     </script>
 
     <script th:inline="javascript">
-        var zmonBootData = {};
+        var zmonBootData = /*[[${zmonBootData}]]*/ {};
     </script>
 
     <link rel="manifest" href="/manifest.json">

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/service/impl/ZMonServiceImplIT.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/service/impl/ZMonServiceImplIT.java
@@ -553,16 +553,4 @@ public class ZMonServiceImplIT {
         MatcherAssert.assertThat(teams,
             Matchers.containsInAnyOrder("Platform/Software", "Platform/RQM", "Platform/Database", "Platform/System"));
     }
-
-    @Test
-    public void testGetStatus() throws Exception {
-        EntitySProcService entitySProcMock = mock(EntitySProcService.class);
-        service = new ZMonServiceImpl(checkDefinitionSProc, alertDefinitionSProc, zmonSProc, entitySProcMock, redisPool, mapper, eventLog, checkRuntimeConfig, config, alertService);
-        when(entitySProcMock.getEntityById(eq("zmon-service-level-config")))
-                .thenReturn(Collections.singletonList("{\"last_modified\":\"\",\"last_modified_by\":\"\",\"data\":{\"query_max_check_tier\": 3, \"ingest_max_check_tier\": 3, \"query_distance_hours_limit\": 0}}"));
-        final ExecutionStatus status = service.getStatus();
-        MatcherAssert.assertThat(status.getServiceLevelStatus().getIngestMaxCheckTier(), Matchers.equalTo(3));
-        MatcherAssert.assertThat(status.getServiceLevelStatus().getQueryDistanceHoursLimit(), Matchers.equalTo(0));
-        MatcherAssert.assertThat(status.getServiceLevelStatus().getQueryMaxCheckTier(), Matchers.equalTo(3));
-    }
 }

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/service/impl/ZMonServiceImplIT.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/service/impl/ZMonServiceImplIT.java
@@ -553,4 +553,16 @@ public class ZMonServiceImplIT {
         MatcherAssert.assertThat(teams,
             Matchers.containsInAnyOrder("Platform/Software", "Platform/RQM", "Platform/Database", "Platform/System"));
     }
+
+    @Test
+    public void testGetStatus() throws Exception {
+        EntitySProcService entitySProcMock = mock(EntitySProcService.class);
+        service = new ZMonServiceImpl(checkDefinitionSProc, alertDefinitionSProc, zmonSProc, entitySProcMock, redisPool, mapper, eventLog, checkRuntimeConfig, config, alertService);
+        when(entitySProcMock.getEntityById(eq("zmon-min-check-interval")))
+                .thenReturn(Collections.singletonList("{\"last_modified\":\"\",\"last_modified_by\":\"\",\"data\":{\"query_max_check_tier\": 3, \"ingest_max_check_tier\": 3, \"query_distance_hours_limit\": 0}}"));
+        final ExecutionStatus status = service.getStatus();
+        MatcherAssert.assertThat(status.getServiceLevelStatus().getIngestMaxCheckTier(), Matchers.equalTo(3));
+        MatcherAssert.assertThat(status.getServiceLevelStatus().getQueryDistanceHoursLimit(), Matchers.equalTo(0));
+        MatcherAssert.assertThat(status.getServiceLevelStatus().getQueryMaxCheckTier(), Matchers.equalTo(3));
+    }
 }

--- a/zmon-controller-app/src/test/java/org/zalando/zmon/service/impl/ZMonServiceImplIT.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/service/impl/ZMonServiceImplIT.java
@@ -558,7 +558,7 @@ public class ZMonServiceImplIT {
     public void testGetStatus() throws Exception {
         EntitySProcService entitySProcMock = mock(EntitySProcService.class);
         service = new ZMonServiceImpl(checkDefinitionSProc, alertDefinitionSProc, zmonSProc, entitySProcMock, redisPool, mapper, eventLog, checkRuntimeConfig, config, alertService);
-        when(entitySProcMock.getEntityById(eq("zmon-min-check-interval")))
+        when(entitySProcMock.getEntityById(eq("zmon-service-level-config")))
                 .thenReturn(Collections.singletonList("{\"last_modified\":\"\",\"last_modified_by\":\"\",\"data\":{\"query_max_check_tier\": 3, \"ingest_max_check_tier\": 3, \"query_distance_hours_limit\": 0}}"));
         final ExecutionStatus status = service.getStatus();
         MatcherAssert.assertThat(status.getServiceLevelStatus().getIngestMaxCheckTier(), Matchers.equalTo(3));

--- a/zmon-controller-ui/js/services/MainAlertService.js
+++ b/zmon-controller-ui/js/services/MainAlertService.js
@@ -204,7 +204,7 @@ angular.module('zmon2App').factory('MainAlertService', ['$http', '$q', '$log', '
                 that.serviceStatus.isStatusRefreshing = true;
                 that.serviceStatus.workers = data.workers;
                 that.serviceStatus.queues = data.queues;
-                that.serviceStatus.serviceLevelStatusMessage = data.service_level_status.message;
+                that.serviceStatus.serviceLevelStatusMessage = data.service_level_status && data.service_level_status.message ? data.service_level_status.message : "";
 
                 // Calculate checks per second for each worker.
                 _.each(that.serviceStatus.workers, function(worker) {

--- a/zmon-controller-ui/js/services/MainAlertService.js
+++ b/zmon-controller-ui/js/services/MainAlertService.js
@@ -204,6 +204,7 @@ angular.module('zmon2App').factory('MainAlertService', ['$http', '$q', '$log', '
                 that.serviceStatus.isStatusRefreshing = true;
                 that.serviceStatus.workers = data.workers;
                 that.serviceStatus.queues = data.queues;
+                that.serviceStatus.serviceLevelStatusMessage = data.service_level_status.message;
 
                 // Calculate checks per second for each worker.
                 _.each(that.serviceStatus.workers, function(worker) {
@@ -295,13 +296,13 @@ angular.module('zmon2App').factory('MainAlertService', ['$http', '$q', '$log', '
             delete this.dataRefreshIntervalPromises[uniqId];
         };
 
-        service.isValidCheckName = function(obj){          
+        service.isValidCheckName = function(obj){
             return new Promise(function(resolve, reject) {
                 CommunicationService.getCheckDefinitions(obj.owning_team.trim()).then(function(items) {
                     var existingWithSameName = items.filter(item=>{
                         return item.name.trim().toLowerCase() == obj.name.trim().toLowerCase() && obj.owning_team.trim().toLowerCase() == item.owning_team.trim().toLowerCase() && obj.id != item.id;
                     });
-    
+
                     if(existingWithSameName.length > 0){
                       resolve(false)
                     }else{
@@ -309,7 +310,7 @@ angular.module('zmon2App').factory('MainAlertService', ['$http', '$q', '$log', '
                     }
                 });
               });
-            
+
         };
         service.isValidAlertName = function(obj){
             return new Promise(function(resolve, reject) {
@@ -317,7 +318,7 @@ angular.module('zmon2App').factory('MainAlertService', ['$http', '$q', '$log', '
                     var existingWithSameName = items.filter(item=>{
                         return item.name.trim().toLowerCase() == obj.name.trim().toLowerCase() && obj.team.trim().toLowerCase() == item.team.trim().toLowerCase() && obj.id != item.id;
                     });
-    
+
                     if(existingWithSameName.length > 0){
                        resolve(false)
                     }else{
@@ -327,13 +328,13 @@ angular.module('zmon2App').factory('MainAlertService', ['$http', '$q', '$log', '
               });
 
         };
-        service.isValidDashboardName = function(obj){          
+        service.isValidDashboardName = function(obj){
             return new Promise(function(resolve, reject) {
                 CommunicationService.getAllDashboards().then(function(items) {
                     var existingWithSameName = items.filter(item=>{
-                        return item.name.trim().toLowerCase() == obj.name.trim().toLowerCase() && obj.id != item.id; 
+                        return item.name.trim().toLowerCase() == obj.name.trim().toLowerCase() && obj.id != item.id;
                     });
-    
+
                     if(existingWithSameName.length > 0){
                        resolve(false)
                     }else{
@@ -341,7 +342,7 @@ angular.module('zmon2App').factory('MainAlertService', ['$http', '$q', '$log', '
                     }
                 });
               });
-            
+
         };
 
         return service;

--- a/zmon-controller-ui/styles/main.css
+++ b/zmon-controller-ui/styles/main.css
@@ -1406,7 +1406,7 @@ code{
 
 .service-level-warning {
     min-height: 30px;
-    background: #ee771a;
+    background: #d40018;
     font-weight: bold;
     color: white;
     display: flex;

--- a/zmon-controller-ui/styles/main.css
+++ b/zmon-controller-ui/styles/main.css
@@ -1402,3 +1402,19 @@ code{
     padding: 10px 15px;
     margin-bottom: 20px;
 }
+
+
+.service-level-warning {
+    margin: 10px;
+    min-height: 30px;
+    background: #ee771a;
+    font-weight: bold;
+    color: white;
+    display: flex;
+    justify-content: center;
+}
+
+.service-level-warning div {
+    font-size: 14px;
+    align-self: center;
+}

--- a/zmon-controller-ui/styles/main.css
+++ b/zmon-controller-ui/styles/main.css
@@ -1405,7 +1405,6 @@ code{
 
 
 .service-level-warning {
-    margin: 10px;
     min-height: 30px;
     background: #ee771a;
     font-weight: bold;
@@ -1415,6 +1414,7 @@ code{
 }
 
 .service-level-warning div {
-    font-size: 14px;
+    margin: 10px;
+    font-size: 16px;
     align-self: center;
 }


### PR DESCRIPTION
Adding the status of the service level config to the `/status` endpoint will enable the addition of a warning message within the UI in case of system degradation and enablement of resiliency measures.