### PR TITLE
Prohibit entity type change

### DIFF
--- a/zmon-controller-app/src/test/java/org/zalando/zmon/api/EntityApiIT.java
+++ b/zmon-controller-app/src/test/java/org/zalando/zmon/api/EntityApiIT.java
@@ -108,4 +108,20 @@ public class EntityApiIT {
         response = executor.execute(getEntity("testentity"));
         assertThat(response.returnResponse().getStatusLine().getStatusCode()).isEqualTo(404);
     }
+
+    @Test
+    public void updateEntityWithTypeGlobalIsForbidden() throws IOException {
+        Executor executor = Executor.newInstance();
+        String initialType = "whatever";
+        String typeToUpdate = "new_whatever";
+        String jsonTemplate = "{\"id\":\"any_id\",\"type\":\"%s\"}";
+
+        Response createResponse = executor.execute(updateEntity(String.format(jsonTemplate, initialType)));
+        int okStatusCode = createResponse.returnResponse().getStatusLine().getStatusCode();
+        assertThat(okStatusCode).isEqualTo(200).as("Entity should be created");
+
+        Response updateResponse = executor.execute(updateEntity(String.format(jsonTemplate, typeToUpdate)));
+        int forbiddenStatusCode = updateResponse.returnResponse().getStatusLine().getStatusCode();
+        assertThat(forbiddenStatusCode).isEqualTo(409).as("Updating entity should be prohibited");
+    }
 }


### PR DESCRIPTION
eagleeye/ZMON#613 prohibit entity type change

If the type is changed, it could lead to different bugs.

Here are several changes which are worth to review:
 - When we are trying to create or update an entity, we fetch it from DB by id. We need this because if the entity with such id exists (which means we are updating, not creating) we need to check the old type.
 - The http error code is `409 Conflict`. The reason for not use `403 Forbidden` is that I would like to distinguish these cases for easier testing. If you think it is not a valid reason, don't hesitate to mention this in the comments.
 - Feel free to say how understandable do you find the fluent approach I've used here (all this Optional/Stream stuff).